### PR TITLE
refactor: テストのモック定義を共通セットアップに統一

### DIFF
--- a/src/components/screens/dashboard.test.tsx
+++ b/src/components/screens/dashboard.test.tsx
@@ -2,37 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Dashboard } from './dashboard';
 import { ParseProvider } from '@/contexts/parse-context';
-
-// Tauri APIをモック
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn().mockImplementation((cmd: string) => {
-    if (cmd === 'get_email_stats') {
-      return Promise.resolve({
-        total_emails: 100,
-        with_body_plain: 80,
-        with_body_html: 90,
-        without_body: 10,
-        avg_plain_length: 500,
-        avg_html_length: 2000,
-      });
-    }
-    if (cmd === 'get_parse_status') {
-      return Promise.resolve({
-        batch_size: 100,
-        parse_status: 'idle',
-        last_parse_started_at: null,
-        last_parse_completed_at: null,
-        last_error_message: null,
-        total_parsed_count: 0,
-      });
-    }
-    return Promise.resolve(null);
-  }),
-}));
-
-vi.mock('@tauri-apps/api/event', () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
+import { mockInvoke, mockListen } from '@/test/setup';
 
 const renderWithProviders = (ui: React.ReactElement) => {
   return render(<ParseProvider>{ui}</ParseProvider>);
@@ -41,6 +11,31 @@ const renderWithProviders = (ui: React.ReactElement) => {
 describe('Dashboard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // セットアップのモックを上書き
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_email_stats') {
+        return Promise.resolve({
+          total_emails: 100,
+          with_body_plain: 80,
+          with_body_html: 90,
+          without_body: 10,
+          avg_plain_length: 500,
+          avg_html_length: 2000,
+        });
+      }
+      if (cmd === 'get_parse_status') {
+        return Promise.resolve({
+          batch_size: 100,
+          parse_status: 'idle',
+          last_parse_started_at: null,
+          last_parse_completed_at: null,
+          last_error_message: null,
+          total_parsed_count: 0,
+        });
+      }
+      return Promise.resolve(null);
+    });
+    mockListen.mockResolvedValue(() => {});
   });
 
   it('renders dashboard heading', () => {

--- a/src/components/screens/settings.test.tsx
+++ b/src/components/screens/settings.test.tsx
@@ -3,37 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { Settings } from './settings';
 import { SyncProvider } from '@/contexts/sync-context';
 import { ParseProvider } from '@/contexts/parse-context';
-
-// Tauri APIをモック
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn().mockImplementation((cmd: string) => {
-    if (cmd === 'get_sync_status') {
-      return Promise.resolve({
-        batch_size: 50,
-        max_iterations: 100,
-        sync_status: 'idle',
-        last_sync_started_at: null,
-        last_sync_completed_at: null,
-        total_synced_count: 0,
-      });
-    }
-    if (cmd === 'get_parse_status') {
-      return Promise.resolve({
-        batch_size: 100,
-        parse_status: 'idle',
-        last_parse_started_at: null,
-        last_parse_completed_at: null,
-        last_error_message: null,
-        total_parsed_count: 0,
-      });
-    }
-    return Promise.resolve(null);
-  }),
-}));
-
-vi.mock('@tauri-apps/api/event', () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
-}));
+import { mockInvoke, mockListen } from '@/test/setup';
 
 const renderWithProviders = (ui: React.ReactElement) => {
   return render(
@@ -46,6 +16,31 @@ const renderWithProviders = (ui: React.ReactElement) => {
 describe('Settings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // セットアップのモックを上書き
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_sync_status') {
+        return Promise.resolve({
+          batch_size: 50,
+          max_iterations: 100,
+          sync_status: 'idle',
+          last_sync_started_at: null,
+          last_sync_completed_at: null,
+          total_synced_count: 0,
+        });
+      }
+      if (cmd === 'get_parse_status') {
+        return Promise.resolve({
+          batch_size: 100,
+          parse_status: 'idle',
+          last_parse_started_at: null,
+          last_parse_completed_at: null,
+          last_error_message: null,
+          total_parsed_count: 0,
+        });
+      }
+      return Promise.resolve(null);
+    });
+    mockListen.mockResolvedValue(() => {});
   });
 
   it('renders settings heading', () => {


### PR DESCRIPTION
## Summary
- `dashboard.test.tsx`, `settings.test.tsx`, `sync.test.tsx`, `sync-context.test.tsx` から重複した `vi.mock` 定義を削除
- `src/test/setup.ts` から export された `mockInvoke`, `mockListen` を各テストで共通利用する形式に統一
- 各テストでは `beforeEach` で `mockImplementation` や `mockResolvedValue` を使用してテスト固有の返り値を上書きする形式に変更

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `src/components/screens/dashboard.test.tsx` | モック定義を削除し、`mockInvoke`, `mockListen` をインポートして利用 |
| `src/components/screens/settings.test.tsx` | 同上 |
| `src/components/screens/sync.test.tsx` | 同上 |
| `src/contexts/sync-context.test.tsx` | 同上 |

## Test plan
- [x] `npm run test:frontend:run` ですべてのテスト (122 tests) がパスすることを確認

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)