### PR TITLE
chore(ci): raise Rust coverage threshold to 70%

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ on:
       - develop
 
 env:
-  COVERAGE_THRESHOLD_RUST: 50
+  COVERAGE_THRESHOLD_RUST: 70
 
 jobs:
   coverage-frontend:


### PR DESCRIPTION
## Summary
- Raise Rust line coverage threshold in GitHub Actions from 50% to 70% using \\COVERAGE_THRESHOLD_RUST\\
- Current backend coverage is about 77%, so builds will remain green while enforcing a stricter bar

## Details
- Workflow: .github/workflows/coverage.yml
- Env: \\COVERAGE_THRESHOLD_RUST: 70\\

## Notes
- Frontend coverage checks (Vitest) are unchanged and still enforced via vitest.config.ts
