### PR TITLE
fix: 商品一覧の画像が表示されない問題を修正

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,10 +22,7 @@
       "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost",
       "assetProtocol": {
         "enable": true,
-        "scope": [
-          "$APPDATA/jp.github.hina0118.paa/images/**",
-          "$HOME/Library/Application Support/jp.github.hina0118.paa/images/**"
-        ]
+        "scope": ["$APPDATA/images/**"]
       }
     },
     "withGlobalTauri": true


### PR DESCRIPTION
## Summary
- `$APPDATA`変数がTauri 2ではすでにアプリ識別子を含むため、assetProtocol.scopeから重複するアプリ識別子パスを削除
- これにより、Windows/macOS両方で正しく画像が参照されるようになる

## Test plan
- [ ] Windowsでアプリを起動し、商品一覧画面で画像が表示されることを確認
- [ ] 画像検索・保存後に画像が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)