### PR TITLE
ci: harden coverage and e2e workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -244,15 +244,15 @@ jobs:
   coverage-status-check:
     name: Coverage Status Check
     runs-on: ubuntu-latest
-    needs: [coverage-frontend, coverage-rust, coverage-e2e-tauri]
+    # NOTE: coverage-e2e-tauri は if:false でスキップ中のため、集約ジョブの依存から外す
+    needs: [coverage-frontend, coverage-rust]
     if: always()
 
     steps:
       - name: Check coverage results
         run: |
           if [[ "${{ needs.coverage-frontend.result }}" == "failure" ]] || \
-             [[ "${{ needs.coverage-rust.result }}" == "failure" ]] || \
-             [[ "${{ needs.coverage-e2e-tauri.result }}" == "failure" ]]; then
+             [[ "${{ needs.coverage-rust.result }}" == "failure" ]]; then
             echo "::error::Coverage check failed. Please ensure all coverage thresholds are met."
             exit 1
           fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,21 @@ jobs:
           CI: true
           # E2E 目標カバレッジ 25% 未達で失敗（coverage-reporter.ts で判定）
 
+      - name: Verify E2E coverage data exists
+        run: |
+          if [ ! -s "coverage-e2e/coverage-data.json" ]; then
+            echo "::error::coverage-e2e/coverage-data.json not found or is empty. E2E coverage threshold check may be skipped."
+            exit 1
+          fi
+
+      - name: Upload E2E coverage data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-coverage-data
+          path: coverage-e2e/coverage-data.json
+          retention-days: 30
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Drop skipped coverage-e2e-tauri dependency from status check
- Fail fast if e2e coverage data is missing and upload it as artifact

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

## 変更内容の要約

<!-- PR説明が変更の主な内容を正確に反映しているか確認してください。例: 主にテスト修正のPRなのか、機能追加＋テスト更新を含むPRなのか。 -->
