### PR TITLE
test(rust): remove sample file dependency in parser tests

### DIFF
--- a/src-tauri/src/parsers/dmm_confirm.rs
+++ b/src-tauri/src/parsers/dmm_confirm.rs
@@ -672,14 +672,33 @@ fn extract_amounts(lines: &[&str]) -> (Option<i64>, Option<i64>, Option<i64>) {
     (subtotal, shipping_fee, total_amount)
 }
 
-// テストはローカル環境でのみ実行（サンプルファイルに個人情報が含まれるため）
-#[cfg(all(test, not(ci)))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_parse_dmm_confirm() {
-        let sample_email = include_str!("../../../sample/dmm_mail_confirm.txt");
+        // NOTE: `sample/` 配下のファイルは使わず、テスト内でダミー本文を生成する。
+        let sample_email = r#"テスト 太郎 様
+
+DMM通販をご利用いただき、ありがとうございます。
+下記の内容にてご注文を承りましたのでご確認ください。
+
+■　ご注文内容確認
+ご注文番号:BS-27599843
+ご注文日：2025/6/1
+
+受取人のお名前：テスト 太郎 様
+
+───────────────────────────────────
+BS-27599843　発送元：千葉配送センター　発送：配送業者は発送時に確定
+───────────────────────────────────
+30MM ARMORED CORE VI FIRES OF RUBICON BALAM INDUSTRIES BD-011 MELANDER 1個 2,530円
+
+商品小計:2,530円
+送料:530円
+お支払い金額:3,060円(税込)
+"#;
         let parser = DmmConfirmParser;
         let result = parser.parse(sample_email);
 

--- a/src-tauri/src/parsers/hobbysearch_cancel.rs
+++ b/src-tauri/src/parsers/hobbysearch_cancel.rs
@@ -77,15 +77,22 @@ fn extract_cancel_quantity(lines: &[&str]) -> Result<i64, String> {
     Ok(1)
 }
 
-#[cfg(all(test, not(ci)))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
+    // NOTE: `sample/` 配下のファイルは使わず、テスト内でダミー本文を生成する。
+    const SAMPLE_EMAIL: &str = r#"件名: 【ホビーサーチ】ご注文のキャンセルが確定しました
+
+注文番号：99-9999-9999
+商品名：【抽選販売】 30MS オプションパーツセット22(ターボコスチュームα)[カラーB] (プラモデル)
+キャンセル個数：1
+"#;
+
     #[test]
     fn test_parse_hobbysearch_cancel() {
-        let sample_email = include_str!("../../../sample/hobbysearch_mail_cancel.txt");
         let parser = HobbySearchCancelParser;
-        let result = parser.parse_cancel(sample_email);
+        let result = parser.parse_cancel(SAMPLE_EMAIL);
 
         assert!(result.is_ok());
         let info = result.unwrap();

--- a/src-tauri/src/parsers/hobbysearch_change.rs
+++ b/src-tauri/src/parsers/hobbysearch_change.rs
@@ -127,14 +127,26 @@ fn extract_purchase_items(lines: &[&str]) -> Result<Vec<OrderItem>, String> {
     }
 }
 
-// テストはローカル環境でのみ実行（サンプルファイルに個人情報が含まれるため）
-#[cfg(all(test, not(ci)))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_parse_hobbysearch_change() {
-        let sample_email = include_str!("../../../sample/hobbysearch_mail_change.txt");
+        // NOTE: `sample/` 配下のファイルは使わず、テスト内でダミー本文を生成する。
+        let sample_email = r#"[注文番号] 12-3456-7890
+
+[商品お届け先]  山田 太郎 様
+〒100-0001 東京都千代田区1-1-1
+
+[ご購入内容]
+バンダイ 2733949 サンプル商品A
+単価：1,000円 × 個数：2 = 2,000円
+
+小計 2,000円
+送料 0円
+合計 2,000円
+"#;
         let parser = HobbySearchChangeParser;
         let result = parser.parse(sample_email);
 

--- a/src-tauri/src/parsers/hobbysearch_change_yoyaku.rs
+++ b/src-tauri/src/parsers/hobbysearch_change_yoyaku.rs
@@ -129,14 +129,25 @@ fn extract_yoyaku_items(lines: &[&str]) -> Result<Vec<OrderItem>, String> {
     }
 }
 
-// テストはローカル環境でのみ実行（サンプルファイルに個人情報が含まれるため）
-#[cfg(all(test, not(ci)))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_parse_hobbysearch_change_yoyaku() {
-        let sample_email = include_str!("../../../sample/hobbysearch_mail_change_yoyaku.txt");
+        // NOTE: `sample/` 配下のファイルは使わず、テスト内でダミー本文を生成する。
+        let sample_email = r#"[注文番号] 12-3456-7890
+
+[商品お届け先]
+山田 太郎 様
+〒100-0001 東京都千代田区1-1-1
+
+[ご予約内容]
+コトブキヤ FG195 サンプル予約商品
+単価：8,096円 × 個数：1 = 8,096円
+
+予約商品合計 8,096円
+"#;
         let parser = HobbySearchChangeYoyakuParser;
         let result = parser.parse(sample_email);
 

--- a/src-tauri/src/parsers/hobbysearch_confirm.rs
+++ b/src-tauri/src/parsers/hobbysearch_confirm.rs
@@ -125,14 +125,33 @@ fn extract_purchase_items(lines: &[&str]) -> Result<Vec<OrderItem>, String> {
     }
 }
 
-// テストはローカル環境でのみ実行（サンプルファイルに個人情報が含まれるため）
-#[cfg(all(test, not(ci)))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_parse_hobbysearch_confirm() {
-        let sample_email = include_str!("../../../sample/hobbysearch_mail_confirm.txt");
+        // NOTE: `sample/` 配下のファイルは使わず、テスト内でダミー本文を生成する。
+        let sample_email = r#"[注文番号] 25-0821-1050
+
+[商品お届け先]
+山田 太郎 様
+〒812-0044 福岡県テスト市1-2-3
+
+[ご購入内容]
+バンダイ 2733949 ★特価品 カスタマイズマテリアル(デコレーションパーツ1 ホワイト)
+単価：462円 × 個数：1 = 462円
+メーカー2 111 商品2
+単価：400円 × 個数：1 = 400円
+メーカー3 222 商品3
+単価：500円 × 個数：1 = 500円
+メーカー4 333 商品4
+単価：524円 × 個数：1 = 524円
+
+小計 1,886円
+送料 660円
+合計 2,546円
+"#;
         let parser = HobbySearchConfirmParser;
         let result = parser.parse(sample_email);
 
@@ -161,7 +180,7 @@ mod tests {
         // 配送先の確認
         assert!(order_info.delivery_address.is_some());
         let address = order_info.delivery_address.unwrap();
-        assert_eq!(address.name, "原田 裕基");
+        assert_eq!(address.name, "山田 太郎");
         assert_eq!(address.postal_code, Some("812-0044".to_string()));
     }
 }

--- a/src-tauri/src/parsers/hobbysearch_confirm_yoyaku.rs
+++ b/src-tauri/src/parsers/hobbysearch_confirm_yoyaku.rs
@@ -127,14 +127,24 @@ fn extract_yoyaku_items(lines: &[&str]) -> Result<Vec<OrderItem>, String> {
     }
 }
 
-// テストはローカル環境でのみ実行（サンプルファイルに個人情報が含まれるため）
-#[cfg(all(test, not(ci)))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_parse_hobbysearch_confirm_yoyaku() {
-        let sample_email = include_str!("../../../sample/hobbysearch_mail_confirm_yoyaku.txt");
+        // NOTE: `sample/` 配下のファイルは使わず、テスト内でダミー本文を生成する。
+        let sample_email = r#"[注文番号] 25-1021-1156
+
+[商品お届け先]  山田 太郎 様
+〒812-0044 福岡県テスト市1-2-3
+
+[ご予約内容]
+コトブキヤ FG195 フレームアームズ・ガール ドゥルガーII 〈ノワールVer.〉
+単価：8,096円 × 個数：1 = 8,096円
+
+予約商品合計 8,096円
+"#;
         let parser = HobbySearchConfirmYoyakuParser;
         let result = parser.parse(sample_email);
 
@@ -161,6 +171,6 @@ mod tests {
         // 配送先の確認
         assert!(order_info.delivery_address.is_some());
         let address = order_info.delivery_address.unwrap();
-        assert_eq!(address.name, "原田 裕基");
+        assert_eq!(address.name, "山田 太郎");
     }
 }

--- a/src-tauri/src/parsers/hobbysearch_send.rs
+++ b/src-tauri/src/parsers/hobbysearch_send.rs
@@ -138,14 +138,40 @@ fn extract_purchase_items(lines: &[&str]) -> Result<Vec<OrderItem>, String> {
     }
 }
 
-// テストはローカル環境でのみ実行（サンプルファイルに個人情報が含まれるため）
-#[cfg(all(test, not(ci)))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_parse_hobbysearch_send() {
-        let sample_email = include_str!("../../../sample/hobbysearch_mail_send.txt");
+        // NOTE: `sample/` 配下のファイルは使わず、テスト内でダミー本文を生成する。
+        let sample_email = r#"[代表注文番号] 25-0807-1624
+
+[商品お届け先]
+山田 太郎 様
+〒812-0044 福岡県テスト市1-2-3
+
+[運送会社] 佐川急便
+[配送伝票] 470550808943
+
+[ご購入内容]
+マックスファクトリー 014554 PLAMAX BP-02 ソフィア・F・シャーリング 虎アーマーVer. (プラモデル)
+単価：9,350円 × 個数：1 = 9,350円
+メーカー2 0002 商品2 (プラモデル)
+単価：12,000円 × 個数：1 = 12,000円
+メーカー3 0003 商品3 (ディスプレイ)
+単価：8,000円 × 個数：1 = 8,000円
+メーカー4 0004 商品4 (プラモデル)
+単価：7,000円 × 個数：1 = 7,000円
+メーカー5 0005 商品5 (プラモデル)
+単価：6,000円 × 個数：1 = 6,000円
+メーカー6 0006 商品6 (プラモデル)
+単価：2,312円 × 個数：2 = 4,624円
+
+小計 46,974円
+送料 0円
+合計 46,974円
+"#;
         let parser = HobbySearchSendParser;
         let result = parser.parse(sample_email);
 
@@ -180,7 +206,7 @@ mod tests {
         // 配送先の確認
         assert!(order_info.delivery_address.is_some());
         let address = order_info.delivery_address.unwrap();
-        assert_eq!(address.name, "原田 裕基");
+        assert_eq!(address.name, "山田 太郎");
         assert_eq!(address.postal_code, Some("812-0044".to_string()));
     }
 }


### PR DESCRIPTION
- Replace include_str!(sample/*) with inline dummy mail bodies
- Run parser tests under CI (cfg(test))

<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

## 変更内容の要約

<!-- PR説明が変更の主な内容を正確に反映しているか確認してください。例: 主にテスト修正のPRなのか、機能追加＋テスト更新を含むPRなのか。 -->
