### PR TITLE
refactor: ParseProvider/SyncProviderの責務を分離する (#151)

### DIFF
--- a/src/contexts/parse-context.test.tsx
+++ b/src/contexts/parse-context.test.tsx
@@ -386,11 +386,10 @@ describe('ParseContext', () => {
   });
 
   it('handles batch-progress event without is_complete (no refresh)', async () => {
-    let progressCallback: ((e: { payload: BatchProgress }) => void) | null =
-      null;
+    const progressCallbacks: ((e: { payload: BatchProgress }) => void)[] = [];
     mockListen.mockImplementation((event: string, cb: (e: unknown) => void) => {
       if (event === BATCH_PROGRESS_EVENT) {
-        progressCallback = cb as (e: { payload: BatchProgress }) => void;
+        progressCallbacks.push(cb as (e: { payload: BatchProgress }) => void);
       }
       return Promise.resolve(() => {});
     });
@@ -410,11 +409,11 @@ describe('ParseContext', () => {
 
     renderHook(() => useParse(), { wrapper });
 
-    await waitFor(() => expect(progressCallback).not.toBeNull());
+    await waitFor(() => expect(progressCallbacks.length).toBeGreaterThan(0));
 
     const countBefore = getParseStatusCallCount;
     await act(async () => {
-      progressCallback?.({
+      const event = {
         payload: {
           task_name: TASK_NAMES.EMAIL_PARSE,
           batch_number: 1,
@@ -427,7 +426,8 @@ describe('ParseContext', () => {
           status_message: 'In progress',
           is_complete: false,
         },
-      });
+      };
+      for (const cb of progressCallbacks) cb(event);
     });
 
     // is_complete=false なので refreshStatus は呼ばれない
@@ -435,11 +435,10 @@ describe('ParseContext', () => {
   });
 
   it('handles batch-progress event with is_complete', async () => {
-    let progressCallback: ((e: { payload: BatchProgress }) => void) | null =
-      null;
+    const progressCallbacks: ((e: { payload: BatchProgress }) => void)[] = [];
     mockListen.mockImplementation((event: string, cb: (e: unknown) => void) => {
       if (event === BATCH_PROGRESS_EVENT) {
-        progressCallback = cb as (e: { payload: BatchProgress }) => void;
+        progressCallbacks.push(cb as (e: { payload: BatchProgress }) => void);
       }
       return Promise.resolve(() => {});
     });
@@ -457,10 +456,10 @@ describe('ParseContext', () => {
 
     renderHook(() => useParse(), { wrapper });
 
-    await waitFor(() => expect(progressCallback).not.toBeNull());
+    await waitFor(() => expect(progressCallbacks.length).toBeGreaterThan(0));
 
     await act(async () => {
-      progressCallback?.({
+      const event = {
         payload: {
           task_name: TASK_NAMES.EMAIL_PARSE,
           batch_number: 1,
@@ -473,41 +472,45 @@ describe('ParseContext', () => {
           status_message: 'Done',
           is_complete: true,
         },
-      });
+      };
+      for (const cb of progressCallbacks) cb(event);
     });
 
     expect(mockInvoke).toHaveBeenCalledWith('get_parse_status');
   });
 
   const setupBatchProgressListener = () => {
-    let progressCallback:
-      | ((e: { payload: BatchProgress }) => Promise<void>)
-      | null = null;
+    const progressCallbacks: ((e: {
+      payload: BatchProgress;
+    }) => Promise<void>)[] = [];
 
     mockListen.mockImplementation((event: string, cb: (e: unknown) => void) => {
       if (event === BATCH_PROGRESS_EVENT) {
-        progressCallback = cb as (e: {
-          payload: BatchProgress;
-        }) => Promise<void>;
+        progressCallbacks.push(
+          cb as (e: { payload: BatchProgress }) => Promise<void>
+        );
       }
       return Promise.resolve(() => {});
     });
 
     return {
-      getProgressCallback: () => progressCallback,
+      hasCallbacks: () => progressCallbacks.length > 0,
+      broadcast: async (event: { payload: BatchProgress }) => {
+        for (const cb of progressCallbacks) await cb(event);
+      },
     };
   };
 
   it('shows toastSuccess on email parse completion when window is visible', async () => {
-    const { getProgressCallback } = setupBatchProgressListener();
+    const { hasCallbacks, broadcast } = setupBatchProgressListener();
 
     isAppWindowVisibleMock.mockResolvedValue(true);
 
     renderHook(() => useParse(), { wrapper });
-    await waitFor(() => expect(getProgressCallback()).not.toBeNull());
+    await waitFor(() => expect(hasCallbacks()).toBe(true));
 
     await act(async () => {
-      await getProgressCallback()?.({
+      await broadcast({
         payload: {
           task_name: TASK_NAMES.EMAIL_PARSE,
           batch_number: 1,
@@ -530,15 +533,15 @@ describe('ParseContext', () => {
   });
 
   it('shows toastError on email parse completion with error when window is visible', async () => {
-    const { getProgressCallback } = setupBatchProgressListener();
+    const { hasCallbacks, broadcast } = setupBatchProgressListener();
 
     isAppWindowVisibleMock.mockResolvedValue(true);
 
     renderHook(() => useParse(), { wrapper });
-    await waitFor(() => expect(getProgressCallback()).not.toBeNull());
+    await waitFor(() => expect(hasCallbacks()).toBe(true));
 
     await act(async () => {
-      await getProgressCallback()?.({
+      await broadcast({
         payload: {
           task_name: TASK_NAMES.EMAIL_PARSE,
           batch_number: 1,
@@ -562,15 +565,15 @@ describe('ParseContext', () => {
   });
 
   it('sends notification on email parse completion when window is not visible', async () => {
-    const { getProgressCallback } = setupBatchProgressListener();
+    const { hasCallbacks, broadcast } = setupBatchProgressListener();
 
     isAppWindowVisibleMock.mockResolvedValue(false);
 
     renderHook(() => useParse(), { wrapper });
-    await waitFor(() => expect(getProgressCallback()).not.toBeNull());
+    await waitFor(() => expect(hasCallbacks()).toBe(true));
 
     await act(async () => {
-      await getProgressCallback()?.({
+      await broadcast({
         payload: {
           task_name: TASK_NAMES.EMAIL_PARSE,
           batch_number: 1,
@@ -593,15 +596,15 @@ describe('ParseContext', () => {
   });
 
   it('sends failure notification on email parse completion when window is not visible', async () => {
-    const { getProgressCallback } = setupBatchProgressListener();
+    const { hasCallbacks, broadcast } = setupBatchProgressListener();
 
     isAppWindowVisibleMock.mockResolvedValue(false);
 
     renderHook(() => useParse(), { wrapper });
-    await waitFor(() => expect(getProgressCallback()).not.toBeNull());
+    await waitFor(() => expect(hasCallbacks()).toBe(true));
 
     await act(async () => {
-      await getProgressCallback()?.({
+      await broadcast({
         payload: {
           task_name: TASK_NAMES.EMAIL_PARSE,
           batch_number: 1,

--- a/src/contexts/parse-provider.tsx
+++ b/src/contexts/parse-provider.tsx
@@ -1,23 +1,18 @@
 import { useState, useEffect, useCallback, type ReactNode } from 'react';
-import { listen } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 import { type ParseMetadata, ParseContext } from './parse-context-value';
-import {
-  type BatchProgress,
-  BATCH_PROGRESS_EVENT,
-  TASK_NAMES,
-} from './batch-progress-types';
-import { toastSuccess, toastError } from '@/lib/toast';
-import { notify, isAppWindowVisible } from '@/lib/utils';
+import { type BatchProgress, TASK_NAMES } from './batch-progress-types';
+import { useBatchNotification } from '@/hooks/useBatchNotification';
+import { useBatchProgressEvent } from '@/hooks/useBatchProgressEvent';
+
+const buildCountMessage = (data: BatchProgress) =>
+  `成功: ${data.success_count}件、失敗: ${data.failed_count}件`;
 
 export function ParseProvider({ children }: { children: ReactNode }) {
   const [isParsing, setIsParsing] = useState(false);
-  const [progress, setProgress] = useState<BatchProgress | null>(null);
   const [metadata, setMetadata] = useState<ParseMetadata | null>(null);
   // 商品名パース (Gemini API)
   const [isProductNameParsing, setIsProductNameParsing] = useState(false);
-  const [productNameProgress, setProductNameProgress] =
-    useState<BatchProgress | null>(null);
   const [geminiApiKeyStatus, setGeminiApiKeyStatus] = useState<
     'checking' | 'available' | 'unavailable' | 'error'
   >('checking');
@@ -43,106 +38,45 @@ export function ParseProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  // 共通イベント（batch-progress）をリッスン
-  useEffect(() => {
-    const unlisten = listen<BatchProgress>(
-      BATCH_PROGRESS_EVENT,
-      async (event) => {
-        const data = event.payload;
+  const notifyEmailParse = useBatchNotification(
+    'メールパース',
+    buildCountMessage,
+    'email parse'
+  );
 
-        // メールパースのイベント
-        if (data.task_name === TASK_NAMES.EMAIL_PARSE) {
-          setProgress(data);
+  const notifyProductNameParse = useBatchNotification(
+    '商品名解析',
+    buildCountMessage,
+    'product name parse'
+  );
 
-          if (data.is_complete) {
-            setIsParsing(false);
-            refreshStatus();
-            const visible = await isAppWindowVisible();
-            if (visible) {
-              if (data.error) {
-                toastError('メールパースに失敗しました', data.error);
-              } else {
-                toastSuccess(
-                  'メールパースが完了しました',
-                  `成功: ${data.success_count}件、失敗: ${data.failed_count}件`
-                );
-              }
-            } else {
-              if (data.error) {
-                try {
-                  await notify('メールパース失敗', data.error);
-                } catch (error) {
-                  console.error(
-                    'Failed to send email parse failure notification:',
-                    error
-                  );
-                }
-              } else {
-                try {
-                  await notify(
-                    'メールパース完了',
-                    `成功: ${data.success_count}件、失敗: ${data.failed_count}件`
-                  );
-                } catch (error) {
-                  console.error(
-                    'Failed to send email parse completion notification:',
-                    error
-                  );
-                }
-              }
-            }
-          }
-        }
+  const handleEmailParseComplete = useCallback(
+    async (data: BatchProgress) => {
+      setIsParsing(false);
+      refreshStatus();
+      await notifyEmailParse(data);
+    },
+    [refreshStatus, notifyEmailParse]
+  );
 
-        // 商品名パースのイベント
-        if (data.task_name === TASK_NAMES.PRODUCT_NAME_PARSE) {
-          setProductNameProgress(data);
+  const handleProductNameParseComplete = useCallback(
+    async (data: BatchProgress) => {
+      setIsProductNameParsing(false);
+      await notifyProductNameParse(data);
+    },
+    [notifyProductNameParse]
+  );
 
-          if (data.is_complete) {
-            setIsProductNameParsing(false);
-            const visible = await isAppWindowVisible();
-            if (visible) {
-              if (data.error) {
-                toastError('商品名解析に失敗しました', data.error);
-              } else {
-                toastSuccess(
-                  '商品名解析が完了しました',
-                  `成功: ${data.success_count}件、失敗: ${data.failed_count}件`
-                );
-              }
-            } else {
-              if (data.error) {
-                try {
-                  await notify('商品名解析失敗', data.error);
-                } catch (error) {
-                  console.error(
-                    'Failed to send product name parse failure notification:',
-                    error
-                  );
-                }
-              } else {
-                try {
-                  await notify(
-                    '商品名解析完了',
-                    `成功: ${data.success_count}件、失敗: ${data.failed_count}件`
-                  );
-                } catch (error) {
-                  console.error(
-                    'Failed to send product name parse completion notification:',
-                    error
-                  );
-                }
-              }
-            }
-          }
-        }
-      }
+  const { progress, setProgress } = useBatchProgressEvent(
+    TASK_NAMES.EMAIL_PARSE,
+    handleEmailParseComplete
+  );
+
+  const { progress: productNameProgress, setProgress: setProductNameProgress } =
+    useBatchProgressEvent(
+      TASK_NAMES.PRODUCT_NAME_PARSE,
+      handleProductNameParseComplete
     );
-
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [refreshStatus]);
 
   useEffect(() => {
     refreshStatus();

--- a/src/contexts/sync-provider.tsx
+++ b/src/contexts/sync-provider.tsx
@@ -1,18 +1,17 @@
 import { useState, useEffect, useCallback, type ReactNode } from 'react';
-import { listen } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 import { type SyncMetadata, SyncContext } from './sync-context-value';
-import {
-  type BatchProgress,
-  BATCH_PROGRESS_EVENT,
-  TASK_NAMES,
-} from './batch-progress-types';
-import { toastSuccess, toastError } from '@/lib/toast';
-import { notify, isAppWindowVisible } from '@/lib/utils';
+import { type BatchProgress, TASK_NAMES } from './batch-progress-types';
+import { useBatchNotification } from '@/hooks/useBatchNotification';
+import { useBatchProgressEvent } from '@/hooks/useBatchProgressEvent';
+
+const buildGmailSuccessMessage = (data: BatchProgress) =>
+  data.success_count > 0
+    ? `新たに${data.success_count}件のメールを取り込みました`
+    : '新規メッセージはありませんでした';
 
 export function SyncProvider({ children }: { children: ReactNode }) {
   const [isSyncing, setIsSyncing] = useState(false);
-  const [progress, setProgress] = useState<BatchProgress | null>(null);
   const [metadata, setMetadata] = useState<SyncMetadata | null>(null);
 
   const refreshStatus = useCallback(async () => {
@@ -25,67 +24,25 @@ export function SyncProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  // 共通イベント（batch-progress）をリッスン
-  useEffect(() => {
-    const unlisten = listen<BatchProgress>(
-      BATCH_PROGRESS_EVENT,
-      async (event) => {
-        const data = event.payload;
+  const notifyGmailSync = useBatchNotification(
+    'Gmail同期',
+    buildGmailSuccessMessage,
+    'Gmail sync'
+  );
 
-        // メール同期のイベントのみ処理
-        if (data.task_name !== TASK_NAMES.GMAIL_SYNC) {
-          return;
-        }
+  const handleGmailComplete = useCallback(
+    async (data: BatchProgress) => {
+      setIsSyncing(false);
+      refreshStatus();
+      await notifyGmailSync(data);
+    },
+    [refreshStatus, notifyGmailSync]
+  );
 
-        setProgress(data);
-
-        if (data.is_complete) {
-          setIsSyncing(false);
-          refreshStatus();
-          const visible = await isAppWindowVisible();
-          if (visible) {
-            if (data.error) {
-              toastError('Gmail同期に失敗しました', data.error);
-            } else {
-              const desc =
-                data.success_count > 0
-                  ? `新たに${data.success_count}件のメールを取り込みました`
-                  : '新規メッセージはありませんでした';
-              toastSuccess('Gmail同期が完了しました', desc);
-            }
-          } else {
-            if (data.error) {
-              try {
-                await notify('Gmail同期失敗', data.error);
-              } catch (error) {
-                console.error(
-                  'Failed to send Gmail sync failure notification:',
-                  error
-                );
-              }
-            } else {
-              const body =
-                data.success_count > 0
-                  ? `新たに${data.success_count}件のメールを取り込みました`
-                  : '新規メッセージはありませんでした';
-              try {
-                await notify('Gmail同期完了', body);
-              } catch (error) {
-                console.error(
-                  'Failed to send Gmail sync completion notification:',
-                  error
-                );
-              }
-            }
-          }
-        }
-      }
-    );
-
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [refreshStatus]);
+  const { progress, setProgress } = useBatchProgressEvent(
+    TASK_NAMES.GMAIL_SYNC,
+    handleGmailComplete
+  );
 
   useEffect(() => {
     const initializeSync = async () => {

--- a/src/hooks/useBatchNotification.test.ts
+++ b/src/hooks/useBatchNotification.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBatchNotification } from './useBatchNotification';
+import type { BatchProgress } from '@/contexts/batch-progress-types';
+
+const { toastSuccessMock, toastErrorMock, notifyMock, isAppWindowVisibleMock } =
+  vi.hoisted(() => ({
+    toastSuccessMock: vi.fn(),
+    toastErrorMock: vi.fn(),
+    notifyMock: vi
+      .fn<[string, string], Promise<void>>()
+      .mockResolvedValue(undefined),
+    isAppWindowVisibleMock: vi
+      .fn<[], Promise<boolean>>()
+      .mockResolvedValue(true),
+  }));
+
+vi.mock('@/lib/toast', () => ({
+  toastSuccess: (...args: unknown[]) => toastSuccessMock(...args),
+  toastError: (...args: unknown[]) => toastErrorMock(...args),
+}));
+
+vi.mock('@/lib/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/utils')>();
+  return {
+    ...actual,
+    notify: (title: string, body: string) => notifyMock(title, body),
+    isAppWindowVisible: () => isAppWindowVisibleMock(),
+  };
+});
+
+function makeBatchProgress(
+  overrides: Partial<BatchProgress> = {}
+): BatchProgress {
+  return {
+    task_name: 'テスト',
+    batch_number: 1,
+    batch_size: 50,
+    total_items: 100,
+    processed_count: 100,
+    success_count: 95,
+    failed_count: 5,
+    progress_percent: 100,
+    status_message: 'Complete',
+    is_complete: true,
+    ...overrides,
+  };
+}
+
+const buildMessage = (p: BatchProgress) =>
+  `成功: ${p.success_count}件、失敗: ${p.failed_count}件`;
+
+describe('useBatchNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isAppWindowVisibleMock.mockResolvedValue(true);
+    notifyMock.mockResolvedValue(undefined);
+  });
+
+  it('calls toastSuccess when window is visible and no error', async () => {
+    const { result } = renderHook(() =>
+      useBatchNotification('メールパース', buildMessage, 'email parse')
+    );
+
+    await act(async () => {
+      await result.current(
+        makeBatchProgress({ success_count: 10, failed_count: 2 })
+      );
+    });
+
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      'メールパースが完了しました',
+      '成功: 10件、失敗: 2件'
+    );
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it('calls toastError when window is visible and data has error', async () => {
+    const { result } = renderHook(() =>
+      useBatchNotification('Gmail同期', buildMessage, 'Gmail sync')
+    );
+
+    await act(async () => {
+      await result.current(makeBatchProgress({ error: 'something broke' }));
+    });
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Gmail同期に失敗しました',
+      'something broke'
+    );
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it('calls notify with short success title when window is not visible and no error', async () => {
+    isAppWindowVisibleMock.mockResolvedValue(false);
+
+    const { result } = renderHook(() =>
+      useBatchNotification('メールパース', buildMessage, 'email parse')
+    );
+
+    await act(async () => {
+      await result.current(
+        makeBatchProgress({ success_count: 5, failed_count: 1 })
+      );
+    });
+
+    expect(notifyMock).toHaveBeenCalledWith(
+      'メールパース完了',
+      '成功: 5件、失敗: 1件'
+    );
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+  });
+
+  it('calls notify with short failure title when window is not visible and data has error', async () => {
+    isAppWindowVisibleMock.mockResolvedValue(false);
+
+    const { result } = renderHook(() =>
+      useBatchNotification('Gmail同期', buildMessage, 'Gmail sync')
+    );
+
+    await act(async () => {
+      await result.current(makeBatchProgress({ error: 'network error' }));
+    });
+
+    expect(notifyMock).toHaveBeenCalledWith('Gmail同期失敗', 'network error');
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('logs console.error when notify throws on success path', async () => {
+    isAppWindowVisibleMock.mockResolvedValue(false);
+    notifyMock.mockRejectedValue(new Error('notify failed'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useBatchNotification('メールパース', buildMessage, 'email parse')
+    );
+
+    await act(async () => {
+      await result.current(makeBatchProgress());
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to send email parse completion notification:',
+      expect.any(Error)
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('logs console.error when notify throws on error path', async () => {
+    isAppWindowVisibleMock.mockResolvedValue(false);
+    notifyMock.mockRejectedValue(new Error('notify failed'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useBatchNotification('Gmail同期', buildMessage, 'Gmail sync')
+    );
+
+    await act(async () => {
+      await result.current(makeBatchProgress({ error: 'sync error' }));
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to send Gmail sync failure notification:',
+      expect.any(Error)
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/hooks/useBatchNotification.ts
+++ b/src/hooks/useBatchNotification.ts
@@ -1,0 +1,56 @@
+import { useCallback } from 'react';
+import type { BatchProgress } from '@/contexts/batch-progress-types';
+import { toastSuccess, toastError } from '@/lib/toast';
+import { notify, isAppWindowVisible } from '@/lib/utils';
+
+/**
+ * ウィンドウ可視性に基づく通知の分岐パターンを共通化するフック
+ *
+ * 可視時: toastSuccess / toastError (丁寧なタイトル)
+ * 非可視時: OS通知 (notify) (短縮タイトル) with try/catch
+ *
+ * タイトル生成パターン:
+ * - toast成功: `${taskLabel}が完了しました`
+ * - toast失敗: `${taskLabel}に失敗しました`
+ * - OS通知成功: `${taskLabel}完了`
+ * - OS通知失敗: `${taskLabel}失敗`
+ */
+export function useBatchNotification(
+  taskLabel: string,
+  buildSuccessMessage: (progress: BatchProgress) => string,
+  notificationContext: string
+): (progress: BatchProgress) => Promise<void> {
+  return useCallback(
+    async (data: BatchProgress) => {
+      const visible = await isAppWindowVisible();
+      if (visible) {
+        if (data.error) {
+          toastError(`${taskLabel}に失敗しました`, data.error);
+        } else {
+          toastSuccess(`${taskLabel}が完了しました`, buildSuccessMessage(data));
+        }
+      } else {
+        if (data.error) {
+          try {
+            await notify(`${taskLabel}失敗`, data.error);
+          } catch (error) {
+            console.error(
+              `Failed to send ${notificationContext} failure notification:`,
+              error
+            );
+          }
+        } else {
+          try {
+            await notify(`${taskLabel}完了`, buildSuccessMessage(data));
+          } catch (error) {
+            console.error(
+              `Failed to send ${notificationContext} completion notification:`,
+              error
+            );
+          }
+        }
+      }
+    },
+    [taskLabel, buildSuccessMessage, notificationContext]
+  );
+}

--- a/src/hooks/useBatchProgressEvent.test.ts
+++ b/src/hooks/useBatchProgressEvent.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useBatchProgressEvent } from './useBatchProgressEvent';
+import { mockListen } from '@/test/setup';
+import {
+  BATCH_PROGRESS_EVENT,
+  TASK_NAMES,
+  type BatchProgress,
+} from '@/contexts/batch-progress-types';
+
+function makeBatchProgress(
+  overrides: Partial<BatchProgress> = {}
+): BatchProgress {
+  return {
+    task_name: TASK_NAMES.GMAIL_SYNC,
+    batch_number: 1,
+    batch_size: 50,
+    total_items: 100,
+    processed_count: 50,
+    success_count: 45,
+    failed_count: 5,
+    progress_percent: 50,
+    status_message: 'In progress',
+    is_complete: false,
+    ...overrides,
+  };
+}
+
+describe('useBatchProgressEvent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListen.mockResolvedValue(() => {});
+  });
+
+  const setupListener = () => {
+    let progressCallback:
+      | ((e: { payload: BatchProgress }) => Promise<void>)
+      | null = null;
+
+    mockListen.mockImplementation((event: string, cb: (e: unknown) => void) => {
+      if (event === BATCH_PROGRESS_EVENT) {
+        progressCallback = cb as (e: {
+          payload: BatchProgress;
+        }) => Promise<void>;
+      }
+      return Promise.resolve(() => {});
+    });
+
+    return {
+      getProgressCallback: () => progressCallback,
+    };
+  };
+
+  it('ignores events with non-matching task_name', async () => {
+    const { getProgressCallback } = setupListener();
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useBatchProgressEvent(TASK_NAMES.GMAIL_SYNC, onComplete)
+    );
+
+    await waitFor(() => expect(getProgressCallback()).not.toBeNull());
+
+    await act(async () => {
+      await getProgressCallback()?.({
+        payload: makeBatchProgress({
+          task_name: TASK_NAMES.EMAIL_PARSE,
+          is_complete: true,
+        }),
+      });
+    });
+
+    expect(result.current.progress).toBeNull();
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('updates progress state on matching event', async () => {
+    const { getProgressCallback } = setupListener();
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useBatchProgressEvent(TASK_NAMES.GMAIL_SYNC, onComplete)
+    );
+
+    await waitFor(() => expect(getProgressCallback()).not.toBeNull());
+
+    const progressData = makeBatchProgress({
+      processed_count: 75,
+      progress_percent: 75,
+    });
+    await act(async () => {
+      await getProgressCallback()?.({ payload: progressData });
+    });
+
+    expect(result.current.progress).toEqual(progressData);
+  });
+
+  it('calls onComplete when is_complete is true', async () => {
+    const { getProgressCallback } = setupListener();
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => useBatchProgressEvent(TASK_NAMES.GMAIL_SYNC, onComplete));
+
+    await waitFor(() => expect(getProgressCallback()).not.toBeNull());
+
+    const completeData = makeBatchProgress({
+      is_complete: true,
+      processed_count: 100,
+      progress_percent: 100,
+    });
+    await act(async () => {
+      await getProgressCallback()?.({ payload: completeData });
+    });
+
+    expect(onComplete).toHaveBeenCalledWith(completeData);
+  });
+
+  it('does not call onComplete when is_complete is false', async () => {
+    const { getProgressCallback } = setupListener();
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() => useBatchProgressEvent(TASK_NAMES.GMAIL_SYNC, onComplete));
+
+    await waitFor(() => expect(getProgressCallback()).not.toBeNull());
+
+    await act(async () => {
+      await getProgressCallback()?.({
+        payload: makeBatchProgress({ is_complete: false }),
+      });
+    });
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('unlistens on unmount', async () => {
+    const unlistenFn = vi.fn();
+    mockListen.mockResolvedValue(unlistenFn);
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+
+    const { unmount } = renderHook(() =>
+      useBatchProgressEvent(TASK_NAMES.GMAIL_SYNC, onComplete)
+    );
+
+    unmount();
+
+    await waitFor(() => expect(unlistenFn).toHaveBeenCalled());
+  });
+
+  it('allows caller to reset progress via setProgress', async () => {
+    const { getProgressCallback } = setupListener();
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useBatchProgressEvent(TASK_NAMES.GMAIL_SYNC, onComplete)
+    );
+
+    await waitFor(() => expect(getProgressCallback()).not.toBeNull());
+
+    // Set progress via event
+    await act(async () => {
+      await getProgressCallback()?.({
+        payload: makeBatchProgress({ processed_count: 50 }),
+      });
+    });
+    expect(result.current.progress).not.toBeNull();
+
+    // Reset via setProgress
+    act(() => {
+      result.current.setProgress(null);
+    });
+    expect(result.current.progress).toBeNull();
+  });
+});

--- a/src/hooks/useBatchProgressEvent.ts
+++ b/src/hooks/useBatchProgressEvent.ts
@@ -1,0 +1,44 @@
+import { useState, useEffect, type Dispatch, type SetStateAction } from 'react';
+import { listen } from '@tauri-apps/api/event';
+import {
+  type BatchProgress,
+  type TaskName,
+  BATCH_PROGRESS_EVENT,
+} from '@/contexts/batch-progress-types';
+
+/**
+ * Tauriのbatch-progressイベントをリッスンし、進捗stateを管理するフック
+ *
+ * - taskNameでフィルタリングし、マッチするイベントのみを処理
+ * - is_complete === true のとき onComplete コールバックを呼び出す
+ * - setProgress を返し、呼び出し側が startXxx 時に null リセット可能
+ */
+export function useBatchProgressEvent(
+  taskName: TaskName,
+  onComplete: (data: BatchProgress) => Promise<void>
+): {
+  progress: BatchProgress | null;
+  setProgress: Dispatch<SetStateAction<BatchProgress | null>>;
+} {
+  const [progress, setProgress] = useState<BatchProgress | null>(null);
+
+  useEffect(() => {
+    const unlisten = listen<BatchProgress>(
+      BATCH_PROGRESS_EVENT,
+      async (event) => {
+        const data = event.payload;
+        if (data.task_name !== taskName) return;
+        setProgress(data);
+        if (data.is_complete) {
+          await onComplete(data);
+        }
+      }
+    );
+
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [taskName, onComplete]);
+
+  return { progress, setProgress };
+}


### PR DESCRIPTION
## Summary
- `useBatchNotification` フックを新規作成: ウィンドウ可視性に基づくトースト/OS通知の分岐パターンを共通化（3箇所の重複を1箇所に集約）
- `useBatchProgressEvent` フックを新規作成: Tauriの `batch-progress` イベントリスナー+進捗state管理を共通化
- `SyncProvider` / `ParseProvider` をリファクタリング: イベントリスニングと通知ロジックを新規フックに委譲し、プロバイダーを状態管理+コマンド呼び出しに専念させる

## Test plan
- [x] `useBatchNotification` の単体テスト (6テスト): 可視/非可視 × 成功/エラー + notify失敗時のエラーハンドリング
- [x] `useBatchProgressEvent` の単体テスト (6テスト): イベントフィルタリング、state更新、onComplete呼び出し、unmount時のunlisten
- [x] `sync-context.test.tsx` の全25テスト通過（変更なし）
- [x] `parse-context.test.tsx` の全23テスト通過（テストインフラのみ更新: 複数listenコールバックのブロードキャスト対応）
- [x] 全538テスト通過

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)