### PR TITLE
refactor: Ordersスクリーンの状態管理を構造化する

### DIFF
--- a/src/components/screens/orders.tsx
+++ b/src/components/screens/orders.tsx
@@ -3,13 +3,9 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { ShoppingCart, Search, LayoutGrid, List } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { useDatabase } from '@/hooks/useDatabase';
-import {
-  loadOrderItems,
-  getOrderItemFilterOptions,
-} from '@/lib/orders-queries';
-import { parseNumericFilter } from '@/lib/utils';
-import { toastError, formatError } from '@/lib/toast';
+import { useDebouncedSearch } from '@/hooks/useDebouncedSearch';
+import { useOrderFilters } from '@/hooks/useOrderFilters';
+import { useOrderItems } from '@/hooks/useOrderItems';
 import { OrderItemCard } from '@/components/orders/order-item-card';
 import { OrderItemRowView } from '@/components/orders/order-item-row';
 import { OrderItemDrawer } from '@/components/orders/order-item-drawer';
@@ -26,115 +22,34 @@ const CARD_ROW_PADDING_AND_GAP = 16 + 16;
 const LIST_ROW_HEIGHT = 80;
 
 export function Orders() {
-  const { getDb } = useDatabase();
-  const [items, setItems] = useState<OrderItemRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [searchInput, setSearchInput] = useState('');
-  const [searchDebounced, setSearchDebounced] = useState('');
-  const [shopDomain, setShopDomain] = useState<string>('');
-  const [year, setYear] = useState<string>('');
-  const [priceMin, setPriceMin] = useState<string>('');
-  const [priceMax, setPriceMax] = useState<string>('');
-  const [filterOptions, setFilterOptions] = useState<{
-    shopDomains: string[];
-    years: number[];
-  }>({ shopDomains: [], years: [] });
-  const [columnCount, setColumnCount] = useState(4);
+  // 検索: デバウンス付き
+  const { searchInput, searchDebounced, setSearchInput, clearSearch } =
+    useDebouncedSearch(SEARCH_DEBOUNCE_MS);
+
+  // フィルタ: shopDomain, year, priceMin, priceMax + ドロップダウン選択肢
+  const { filters, setFilter, clearFilters, filterOptions } = useOrderFilters();
+
+  // データ取得 + ソート + ドロワー状態
+  const {
+    items,
+    loading,
+    sort,
+    setSort,
+    selectedItem,
+    drawerOpen,
+    openDrawer,
+    setDrawerOpen,
+    handleImageUpdated,
+  } = useOrderItems({ searchDebounced, filters });
+
+  // 表示設定（純粋な表示制御のためローカル状態で十分）
   const [viewMode, setViewMode] = useState<'card' | 'list'>('card');
-  const [sortBy, setSortBy] = useState<'order_date' | 'price'>('order_date');
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
-  const [selectedItem, setSelectedItem] = useState<OrderItemRow | null>(null);
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const loadItemsRequestId = useRef(0);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setSearchDebounced(searchInput);
-    }, SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [searchInput]);
-
-  const loadFilters = useCallback(async () => {
-    try {
-      const db = await getDb();
-      const options = await getOrderItemFilterOptions(db);
-      setFilterOptions(options);
-    } catch (err) {
-      toastError(
-        `フィルタオプションの読み込みに失敗しました: ${formatError(err)}`
-      );
-      console.error('Failed to load filter options:', err);
-    }
-  }, [getDb]);
-
-  const loadItems = useCallback(async (): Promise<
-    OrderItemRow[] | undefined
-  > => {
-    const requestId = (loadItemsRequestId.current += 1);
-    setLoading(true);
-    try {
-      const db = await getDb();
-      const rows = await loadOrderItems(db, {
-        search: searchDebounced || undefined,
-        shopDomain: shopDomain || undefined,
-        year: parseNumericFilter(year),
-        priceMin: parseNumericFilter(priceMin),
-        priceMax: parseNumericFilter(priceMax),
-        sortBy,
-        sortOrder,
-      });
-      if (requestId === loadItemsRequestId.current) {
-        setItems(rows);
-        return rows;
-      }
-      return undefined;
-    } catch (err) {
-      if (requestId === loadItemsRequestId.current) {
-        toastError(`商品一覧の読み込みに失敗しました: ${formatError(err)}`);
-        console.error('Failed to load order items:', err);
-        setItems([]);
-      }
-      return undefined;
-    } finally {
-      if (requestId === loadItemsRequestId.current) {
-        setLoading(false);
-      }
-    }
-  }, [
-    getDb,
-    searchDebounced,
-    shopDomain,
-    year,
-    priceMin,
-    priceMax,
-    sortBy,
-    sortOrder,
-  ]);
-
-  useEffect(() => {
-    loadFilters();
-  }, [loadFilters]);
-
-  useEffect(() => {
-    loadItems();
-  }, [loadItems]);
+  const [columnCount, setColumnCount] = useState(4);
 
   const handleClearFilters = () => {
-    setSearchInput('');
-    setSearchDebounced('');
-    setShopDomain('');
-    setYear('');
-    setPriceMin('');
-    setPriceMax('');
+    clearSearch();
+    clearFilters();
   };
-
-  const handleImageUpdated = useCallback(async () => {
-    const newItems = await loadItems();
-    if (newItems && selectedItem) {
-      const updated = newItems.find((i) => i.id === selectedItem.id);
-      if (updated) setSelectedItem(updated);
-    }
-  }, [loadItems, selectedItem]);
 
   return (
     <div className="container mx-auto py-10 px-6">
@@ -198,8 +113,8 @@ export function Orders() {
             </label>
             <select
               id="filter-shop"
-              value={shopDomain}
-              onChange={(e) => setShopDomain(e.target.value)}
+              value={filters.shopDomain}
+              onChange={(e) => setFilter('shopDomain', e.target.value)}
               className="h-9 rounded-md border border-input bg-transparent px-3 text-sm"
             >
               <option value="">すべて</option>
@@ -219,8 +134,8 @@ export function Orders() {
             </label>
             <select
               id="filter-year"
-              value={year}
-              onChange={(e) => setYear(e.target.value)}
+              value={filters.year}
+              onChange={(e) => setFilter('year', e.target.value)}
               className="h-9 rounded-md border border-input bg-transparent px-3 text-sm"
             >
               <option value="">すべて</option>
@@ -240,14 +155,13 @@ export function Orders() {
             </label>
             <select
               id="sort"
-              value={`${sortBy}-${sortOrder}`}
+              value={`${sort.sortBy}-${sort.sortOrder}`}
               onChange={(e) => {
                 const [by, order] = e.target.value.split('-') as [
                   'order_date' | 'price',
                   'asc' | 'desc',
                 ];
-                setSortBy(by);
-                setSortOrder(order);
+                setSort({ sortBy: by, sortOrder: order });
               }}
               className="h-9 rounded-md border border-input bg-transparent px-3 text-sm"
             >
@@ -268,8 +182,8 @@ export function Orders() {
               id="filter-price-min"
               type="number"
               placeholder="最小"
-              value={priceMin}
-              onChange={(e) => setPriceMin(e.target.value)}
+              value={filters.priceMin}
+              onChange={(e) => setFilter('priceMin', e.target.value)}
               className="w-24 h-9"
             />
             <span className="text-muted-foreground">〜</span>
@@ -277,8 +191,8 @@ export function Orders() {
               id="filter-price-max"
               type="number"
               placeholder="最大"
-              value={priceMax}
-              onChange={(e) => setPriceMax(e.target.value)}
+              value={filters.priceMax}
+              onChange={(e) => setFilter('priceMax', e.target.value)}
               className="w-24 h-9"
             />
             <span className="text-sm text-muted-foreground">円</span>
@@ -300,10 +214,7 @@ export function Orders() {
           viewMode={viewMode}
           columnCount={viewMode === 'list' ? 1 : columnCount}
           onColumnCountChange={setColumnCount}
-          onItemClick={(item) => {
-            setSelectedItem(item);
-            setDrawerOpen(true);
-          }}
+          onItemClick={openDrawer}
         />
       )}
       <OrderItemDrawer

--- a/src/hooks/useDebouncedSearch.test.ts
+++ b/src/hooks/useDebouncedSearch.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebouncedSearch } from './useDebouncedSearch';
+
+describe('useDebouncedSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('initializes with empty strings', () => {
+    const { result } = renderHook(() => useDebouncedSearch());
+
+    expect(result.current.searchInput).toBe('');
+    expect(result.current.searchDebounced).toBe('');
+  });
+
+  it('updates searchInput immediately on setSearchInput', () => {
+    const { result } = renderHook(() => useDebouncedSearch());
+
+    act(() => {
+      result.current.setSearchInput('hello');
+    });
+
+    expect(result.current.searchInput).toBe('hello');
+    expect(result.current.searchDebounced).toBe('');
+  });
+
+  it('updates searchDebounced after delay', () => {
+    const { result } = renderHook(() => useDebouncedSearch(300));
+
+    act(() => {
+      result.current.setSearchInput('hello');
+    });
+
+    // Before delay
+    expect(result.current.searchDebounced).toBe('');
+
+    // After delay
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current.searchDebounced).toBe('hello');
+  });
+
+  it('resets debounce timer on rapid input', () => {
+    const { result } = renderHook(() => useDebouncedSearch(300));
+
+    act(() => {
+      result.current.setSearchInput('h');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    act(() => {
+      result.current.setSearchInput('he');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // 400ms total but only 200ms since last input
+    expect(result.current.searchDebounced).toBe('');
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current.searchDebounced).toBe('he');
+  });
+
+  it('clearSearch resets both values synchronously', () => {
+    const { result } = renderHook(() => useDebouncedSearch(300));
+
+    act(() => {
+      result.current.setSearchInput('hello');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current.searchInput).toBe('hello');
+    expect(result.current.searchDebounced).toBe('hello');
+
+    act(() => {
+      result.current.clearSearch();
+    });
+
+    expect(result.current.searchInput).toBe('');
+    expect(result.current.searchDebounced).toBe('');
+  });
+
+  it('uses custom delay', () => {
+    const { result } = renderHook(() => useDebouncedSearch(500));
+
+    act(() => {
+      result.current.setSearchInput('test');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current.searchDebounced).toBe('');
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current.searchDebounced).toBe('test');
+  });
+
+  it('uses default delay of 300ms when not specified', () => {
+    const { result } = renderHook(() => useDebouncedSearch());
+
+    act(() => {
+      result.current.setSearchInput('test');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+
+    expect(result.current.searchDebounced).toBe('');
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(result.current.searchDebounced).toBe('test');
+  });
+
+  it('clearSearch prevents pending debounce from firing', () => {
+    const { result } = renderHook(() => useDebouncedSearch(300));
+
+    act(() => {
+      result.current.setSearchInput('hello');
+    });
+
+    // Clear before debounce fires
+    act(() => {
+      result.current.clearSearch();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current.searchInput).toBe('');
+    expect(result.current.searchDebounced).toBe('');
+  });
+});

--- a/src/hooks/useDebouncedSearch.ts
+++ b/src/hooks/useDebouncedSearch.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const DEFAULT_DELAY_MS = 300;
+
+/**
+ * 検索入力のデバウンスを管理する汎用フック
+ *
+ * - `searchInput` はユーザーの入力に即座に追従する（UI表示用）
+ * - `searchDebounced` は入力停止後 `delayMs` ミリ秒で更新される（クエリ用）
+ * - `clearSearch()` は両方を同期的にリセットする
+ *
+ * @param delayMs - デバウンス遅延（ミリ秒）。デフォルト 300ms
+ */
+export function useDebouncedSearch(delayMs: number = DEFAULT_DELAY_MS) {
+  const [searchInput, setSearchInput] = useState('');
+  const [searchDebounced, setSearchDebounced] = useState('');
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchDebounced(searchInput);
+    }, delayMs);
+    return () => clearTimeout(timer);
+  }, [searchInput, delayMs]);
+
+  const clearSearch = useCallback(() => {
+    setSearchInput('');
+    setSearchDebounced('');
+  }, []);
+
+  return {
+    searchInput,
+    searchDebounced,
+    setSearchInput,
+    clearSearch,
+  };
+}

--- a/src/hooks/useOrderFilters.test.ts
+++ b/src/hooks/useOrderFilters.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useOrderFilters } from './useOrderFilters';
+
+const mockGetDb = vi.fn();
+
+vi.mock('@/hooks/useDatabase', () => ({
+  useDatabase: () => ({
+    getDb: mockGetDb,
+  }),
+}));
+
+const mockDb = {
+  select: vi.fn(),
+};
+
+describe('useOrderFilters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDb.mockResolvedValue(mockDb);
+    // Default: return empty filter options
+    mockDb.select.mockResolvedValue([]);
+  });
+
+  it('initializes with empty filter values', () => {
+    const { result } = renderHook(() => useOrderFilters());
+
+    expect(result.current.filters).toEqual({
+      shopDomain: '',
+      year: '',
+      priceMin: '',
+      priceMax: '',
+    });
+  });
+
+  it('initializes with empty filter options', () => {
+    const { result } = renderHook(() => useOrderFilters());
+
+    expect(result.current.filterOptions).toEqual({
+      shopDomains: [],
+      years: [],
+    });
+  });
+
+  it('loads filter options from database on mount', async () => {
+    mockDb.select.mockImplementation((sql: string) => {
+      if (
+        sql.includes('COALESCE(oo.shop_name, o.shop_name, o.shop_domain)') ||
+        sql.includes('COALESCE(shop_name, shop_domain)')
+      ) {
+        return Promise.resolve([
+          { shop_display: 'shop-a.com' },
+          { shop_display: 'shop-b.com' },
+        ]);
+      }
+      if (sql.includes("strftime('%Y'")) {
+        return Promise.resolve([{ yr: '2024' }, { yr: '2023' }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const { result } = renderHook(() => useOrderFilters());
+
+    await waitFor(() => {
+      expect(result.current.filterOptions.shopDomains).toEqual([
+        'shop-a.com',
+        'shop-b.com',
+      ]);
+    });
+
+    expect(result.current.filterOptions.years).toEqual([2024, 2023]);
+  });
+
+  it('setFilter updates individual filter field', () => {
+    const { result } = renderHook(() => useOrderFilters());
+
+    act(() => {
+      result.current.setFilter('shopDomain', 'test.com');
+    });
+
+    expect(result.current.filters.shopDomain).toBe('test.com');
+    expect(result.current.filters.year).toBe('');
+    expect(result.current.filters.priceMin).toBe('');
+    expect(result.current.filters.priceMax).toBe('');
+  });
+
+  it('setFilter updates multiple fields independently', () => {
+    const { result } = renderHook(() => useOrderFilters());
+
+    act(() => {
+      result.current.setFilter('shopDomain', 'test.com');
+    });
+
+    act(() => {
+      result.current.setFilter('year', '2024');
+    });
+
+    act(() => {
+      result.current.setFilter('priceMin', '100');
+    });
+
+    act(() => {
+      result.current.setFilter('priceMax', '5000');
+    });
+
+    expect(result.current.filters).toEqual({
+      shopDomain: 'test.com',
+      year: '2024',
+      priceMin: '100',
+      priceMax: '5000',
+    });
+  });
+
+  it('clearFilters resets all filter values to empty strings', () => {
+    const { result } = renderHook(() => useOrderFilters());
+
+    act(() => {
+      result.current.setFilter('shopDomain', 'test.com');
+      result.current.setFilter('year', '2024');
+      result.current.setFilter('priceMin', '100');
+      result.current.setFilter('priceMax', '5000');
+    });
+
+    act(() => {
+      result.current.clearFilters();
+    });
+
+    expect(result.current.filters).toEqual({
+      shopDomain: '',
+      year: '',
+      priceMin: '',
+      priceMax: '',
+    });
+  });
+
+  it('handles filter options load failure gracefully', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockDb.select.mockRejectedValue(new Error('DB error'));
+
+    const { result } = renderHook(() => useOrderFilters());
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to load filter options:',
+        expect.any(Error)
+      );
+    });
+
+    // Filter options remain empty on error
+    expect(result.current.filterOptions).toEqual({
+      shopDomains: [],
+      years: [],
+    });
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/hooks/useOrderFilters.ts
+++ b/src/hooks/useOrderFilters.ts
@@ -1,0 +1,88 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useDatabase } from '@/hooks/useDatabase';
+import { getOrderItemFilterOptions } from '@/lib/orders-queries';
+import { toastError, formatError } from '@/lib/toast';
+
+/**
+ * フィルタ状態の型定義
+ *
+ * すべて string 型: `<input>` / `<select>` に直接バインドし、
+ * number への変換はクエリ実行時に `parseNumericFilter()` で行う
+ */
+export type OrdersFilterState = {
+  shopDomain: string;
+  year: string;
+  priceMin: string;
+  priceMax: string;
+};
+
+/** フィルタドロップダウンの選択肢 */
+export type OrdersFilterOptions = {
+  shopDomains: string[];
+  years: number[];
+};
+
+const INITIAL_FILTERS: OrdersFilterState = {
+  shopDomain: '',
+  year: '',
+  priceMin: '',
+  priceMax: '',
+};
+
+const INITIAL_OPTIONS: OrdersFilterOptions = {
+  shopDomains: [],
+  years: [],
+};
+
+/**
+ * Ordersスクリーンのフィルタ状態を管理するフック
+ *
+ * - 4つのフィルタ値（shopDomain, year, priceMin, priceMax）を単一オブジェクトで管理
+ * - マウント時にDBからフィルタ選択肢（ショップ一覧、年一覧）をロード
+ * - `setFilter('key', value)` で型安全に個別フィールドを更新
+ * - `clearFilters()` で全フィルタを空文字にリセット
+ */
+export function useOrderFilters() {
+  const { getDb } = useDatabase();
+  const [filters, setFilters] = useState<OrdersFilterState>(INITIAL_FILTERS);
+  const [filterOptions, setFilterOptions] =
+    useState<OrdersFilterOptions>(INITIAL_OPTIONS);
+
+  const setFilter = useCallback(
+    <K extends keyof OrdersFilterState>(
+      key: K,
+      value: OrdersFilterState[K]
+    ) => {
+      setFilters((prev) => ({ ...prev, [key]: value }));
+    },
+    []
+  );
+
+  const clearFilters = useCallback(() => {
+    setFilters(INITIAL_FILTERS);
+  }, []);
+
+  const loadFilterOptions = useCallback(async () => {
+    try {
+      const db = await getDb();
+      const options = await getOrderItemFilterOptions(db);
+      setFilterOptions(options);
+    } catch (err) {
+      toastError(
+        `フィルタオプションの読み込みに失敗しました: ${formatError(err)}`
+      );
+      console.error('Failed to load filter options:', err);
+    }
+  }, [getDb]);
+
+  useEffect(() => {
+    loadFilterOptions();
+  }, [loadFilterOptions]);
+
+  return {
+    filters,
+    setFilter,
+    clearFilters,
+    filterOptions,
+  };
+}

--- a/src/hooks/useOrderItems.test.ts
+++ b/src/hooks/useOrderItems.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useOrderItems } from './useOrderItems';
+import type { OrdersFilterState } from './useOrderFilters';
+import type { OrderItemRow } from '@/lib/types';
+
+const mockGetDb = vi.fn();
+
+vi.mock('@/hooks/useDatabase', () => ({
+  useDatabase: () => ({
+    getDb: mockGetDb,
+  }),
+}));
+
+const mockDb = {
+  select: vi.fn(),
+};
+
+const EMPTY_FILTERS: OrdersFilterState = {
+  shopDomain: '',
+  year: '',
+  priceMin: '',
+  priceMax: '',
+};
+
+function makeMockItem(overrides: Partial<OrderItemRow> = {}): OrderItemRow {
+  return {
+    id: 1,
+    orderId: 1,
+    originalOrderNumber: 'ORD-1',
+    originalOrderDate: '2024-01-01',
+    originalShopName: null,
+    originalItemName: 'Test Item',
+    originalBrand: '',
+    originalPrice: 1000,
+    originalQuantity: 1,
+    originalCategory: null,
+    itemOverrideCategory: null,
+    itemName: 'Test Item',
+    itemNameNormalized: null,
+    price: 1000,
+    quantity: 1,
+    category: null,
+    brand: null,
+    createdAt: '2024-01-01',
+    shopName: 'Test Shop',
+    shopDomain: 'test.com',
+    orderNumber: 'ORD-1',
+    orderDate: '2024-01-01',
+    fileName: null,
+    deliveryStatus: null,
+    maker: null,
+    series: null,
+    productName: null,
+    scale: null,
+    isReissue: null,
+    hasOverride: 0,
+    ...overrides,
+  } as OrderItemRow;
+}
+
+describe('useOrderItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDb.mockResolvedValue(mockDb);
+    mockDb.select.mockResolvedValue([]);
+  });
+
+  it('initializes with loading=true and empty items', () => {
+    const { result } = renderHook(() =>
+      useOrderItems({ searchDebounced: '', filters: EMPTY_FILTERS })
+    );
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('loads items on mount', async () => {
+    const mockItem = makeMockItem();
+    mockDb.select.mockResolvedValue([mockItem]);
+
+    const { result } = renderHook(() =>
+      useOrderItems({ searchDebounced: '', filters: EMPTY_FILTERS })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.items).toEqual([mockItem]);
+  });
+
+  it('initializes with default sort state', () => {
+    const { result } = renderHook(() =>
+      useOrderItems({ searchDebounced: '', filters: EMPTY_FILTERS })
+    );
+
+    expect(result.current.sort).toEqual({
+      sortBy: 'order_date',
+      sortOrder: 'desc',
+    });
+  });
+
+  it('setSort updates sort state', async () => {
+    mockDb.select.mockResolvedValue([]);
+
+    const { result } = renderHook(() =>
+      useOrderItems({ searchDebounced: '', filters: EMPTY_FILTERS })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      result.current.setSort({ sortBy: 'price', sortOrder: 'asc' });
+    });
+
+    expect(result.current.sort).toEqual({
+      sortBy: 'price',
+      sortOrder: 'asc',
+    });
+  });
+
+  it('reloads items when sort changes', async () => {
+    mockDb.select.mockResolvedValue([]);
+
+    const { result } = renderHook(() =>
+      useOrderItems({ searchDebounced: '', filters: EMPTY_FILTERS })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const initialCallCount = mockDb.select.mock.calls.length;
+
+    act(() => {
+      result.current.setSort({ sortBy: 'price', sortOrder: 'asc' });
+    });
+
+    await waitFor(() => {
+      expect(mockDb.select.mock.calls.length).toBeGreaterThan(initialCallCount);
+    });
+  });
+
+  it('reloads items when filters change', async () => {
+    mockDb.select.mockResolvedValue([]);
+
+    const { result, rerender } = renderHook(
+      ({ filters }: { filters: OrdersFilterState }) =>
+        useOrderItems({ searchDebounced: '', filters }),
+      { initialProps: { filters: EMPTY_FILTERS } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const initialCallCount = mockDb.select.mock.calls.length;
+
+    rerender({
+      filters: { ...EMPTY_FILTERS, shopDomain: 'test.com' },
+    });
+
+    await waitFor(() => {
+      expect(mockDb.select.mock.calls.length).toBeGreaterThan(initialCallCount);
+    });
+  });
+
+  it('reloads items when searchDebounced changes', async () => {
+    mockDb.select.mockResolvedValue([]);
+
+    const { result, rerender } = renderHook(
+      ({ search }: { search: string }) =>
+        useOrderItems({ searchDebounced: search, filters: EMPTY_FILTERS }),
+      { initialProps: { search: '' } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const initialCallCount = mockDb.select.mock.calls.length;
+
+    rerender({ search: 'test query' });
+
+    await waitFor(() => {
+      expect(mockDb.select.mock.calls.length).toBeGreaterThan(initialCallCount);
+    });
+  });
+
+  it('initializes drawer state as closed', () => {
+    const { result } = renderHook(() =>
+      useOrderItems({ searchDebounced: '', filters: EMPTY_FILTERS })
+    );
+
+    expect(result.current.selectedItem).toBeNull();
+    expect(result.current.drawerOpen).toBe(false);
+  });
+
+  it('openDrawer sets selectedItem and opens drawer', () => {
+    const { result } = renderHook(() =>
+      useOrderItems({ searchDebounced: '', filters: EMPTY_FILTERS })
+    );
+
+    const mockItem = makeMockItem();
+
+    act(() => {
+      result.current.openDrawer(mockItem);
+    });
+
+    expect(result.current.selectedItem).toEqual(mockItem);
+    expect(result.current.drawerOpen).toBe(true);
+  });
+
+  it('setDrawerOpen controls drawer open state', () => {
+    const { result } = renderHook(() =>
+      useOrderItems({ searchDebounced: '', filters: EMPTY_FILTERS })
+    );
+
+    const mockItem = makeMockItem();
+
+    act(() => {
+      result.current.openDrawer(mockItem);
+    });
+
+    expect(result.current.drawerOpen).toBe(true);
+
+    act(() => {
+      result.current.setDrawerOpen(false);
+    });
+
+    expect(result.current.drawerOpen).toBe(false);
+  });
+
+  it('handles loadItems failure gracefully', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockDb.select.mockRejectedValue(new Error('DB error'));
+
+    const { result } = renderHook(() =>
+      useOrderItems({ searchDebounced: '', filters: EMPTY_FILTERS })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.items).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to load order items:',
+      expect.any(Error)
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handleImageUpdated reloads items and updates selectedItem', async () => {
+    const originalItem = makeMockItem({ id: 1, fileName: null });
+    const updatedItem = makeMockItem({ id: 1, fileName: 'new-image.jpg' });
+
+    // Initial load returns original item
+    mockDb.select.mockResolvedValue([originalItem]);
+
+    const { result } = renderHook(() =>
+      useOrderItems({ searchDebounced: '', filters: EMPTY_FILTERS })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Open drawer with item
+    act(() => {
+      result.current.openDrawer(originalItem);
+    });
+
+    // Now mock returns updated item
+    mockDb.select.mockResolvedValue([updatedItem]);
+
+    // Call handleImageUpdated
+    await act(async () => {
+      await result.current.handleImageUpdated();
+    });
+
+    expect(result.current.selectedItem).toEqual(updatedItem);
+    expect(result.current.items).toEqual([updatedItem]);
+  });
+
+  it('discards stale request results (requestId pattern)', async () => {
+    const item1 = makeMockItem({ id: 1, itemName: 'First' });
+    const item2 = makeMockItem({ id: 2, itemName: 'Second' });
+
+    // First call: resolve slowly
+    // Second call: resolve immediately with different data
+    let resolveFirst: ((value: unknown[]) => void) | null = null;
+    let callCount = 0;
+
+    mockDb.select.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return new Promise<unknown[]>((resolve) => {
+          resolveFirst = resolve;
+        });
+      }
+      return Promise.resolve([item2]);
+    });
+
+    const { result, rerender } = renderHook(
+      ({ search }: { search: string }) =>
+        useOrderItems({ searchDebounced: search, filters: EMPTY_FILTERS }),
+      { initialProps: { search: '' } }
+    );
+
+    // Trigger second load before first completes
+    rerender({ search: 'query' });
+
+    // Wait for second request to complete
+    await waitFor(() => {
+      expect(result.current.items).toEqual([item2]);
+    });
+
+    // Now resolve the first (stale) request
+    resolveFirst?.([item1]);
+
+    // Items should still show second result (stale result is discarded)
+    // Give time for any potential state update
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(result.current.items).toEqual([item2]);
+  });
+});

--- a/src/hooks/useOrderItems.ts
+++ b/src/hooks/useOrderItems.ts
@@ -1,0 +1,126 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useDatabase } from '@/hooks/useDatabase';
+import { loadOrderItems } from '@/lib/orders-queries';
+import { parseNumericFilter } from '@/lib/utils';
+import { toastError, formatError } from '@/lib/toast';
+import type { OrderItemRow } from '@/lib/types';
+import type { OrdersFilterState } from '@/hooks/useOrderFilters';
+
+/** ソート状態の型定義 */
+export type OrdersSortState = {
+  sortBy: 'order_date' | 'price';
+  sortOrder: 'asc' | 'desc';
+};
+
+const INITIAL_SORT: OrdersSortState = {
+  sortBy: 'order_date',
+  sortOrder: 'desc',
+};
+
+type UseOrderItemsParams = {
+  searchDebounced: string;
+  filters: OrdersFilterState;
+};
+
+/**
+ * Ordersスクリーンのデータ取得・ソート・ドロワー状態を管理するフック
+ *
+ * ## 責務
+ * - 商品データの取得（requestId パターンによる競合状態防止）
+ * - ソート状態（sortBy, sortOrder）の管理
+ * - 選択中アイテム・ドロワーの開閉状態の管理
+ * - 画像更新後のデータ再読み込み + selectedItem の同期
+ *
+ * ## requestId パターン
+ * `loadOrderItems()` は tauri-plugin-sql 経由の非同期IPC呼び出しのため
+ * AbortController ではキャンセルできない。requestId を使って
+ * 古いリクエストの結果が新しいリクエストの結果を上書きするのを防ぐ。
+ */
+export function useOrderItems({
+  searchDebounced,
+  filters,
+}: UseOrderItemsParams) {
+  const { getDb } = useDatabase();
+  const [items, setItems] = useState<OrderItemRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [sort, setSort] = useState<OrdersSortState>(INITIAL_SORT);
+  const [selectedItem, setSelectedItem] = useState<OrderItemRow | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const loadItemsRequestId = useRef(0);
+
+  // フィルタを個別フィールドに展開（useEffect の依存配列で使用）
+  const { shopDomain, year, priceMin, priceMax } = filters;
+
+  const loadItems = useCallback(async (): Promise<
+    OrderItemRow[] | undefined
+  > => {
+    const requestId = (loadItemsRequestId.current += 1);
+    setLoading(true);
+    try {
+      const db = await getDb();
+      const rows = await loadOrderItems(db, {
+        search: searchDebounced || undefined,
+        shopDomain: shopDomain || undefined,
+        year: parseNumericFilter(year),
+        priceMin: parseNumericFilter(priceMin),
+        priceMax: parseNumericFilter(priceMax),
+        sortBy: sort.sortBy,
+        sortOrder: sort.sortOrder,
+      });
+      if (requestId === loadItemsRequestId.current) {
+        setItems(rows);
+        return rows;
+      }
+      return undefined;
+    } catch (err) {
+      if (requestId === loadItemsRequestId.current) {
+        toastError(`商品一覧の読み込みに失敗しました: ${formatError(err)}`);
+        console.error('Failed to load order items:', err);
+        setItems([]);
+      }
+      return undefined;
+    } finally {
+      if (requestId === loadItemsRequestId.current) {
+        setLoading(false);
+      }
+    }
+  }, [
+    getDb,
+    searchDebounced,
+    shopDomain,
+    year,
+    priceMin,
+    priceMax,
+    sort.sortBy,
+    sort.sortOrder,
+  ]);
+
+  useEffect(() => {
+    loadItems();
+  }, [loadItems]);
+
+  const openDrawer = useCallback((item: OrderItemRow) => {
+    setSelectedItem(item);
+    setDrawerOpen(true);
+  }, []);
+
+  const handleImageUpdated = useCallback(async () => {
+    const newItems = await loadItems();
+    if (newItems && selectedItem) {
+      const updated = newItems.find((i) => i.id === selectedItem.id);
+      if (updated) setSelectedItem(updated);
+    }
+  }, [loadItems, selectedItem]);
+
+  return {
+    items,
+    loading,
+    sort,
+    setSort,
+    selectedItem,
+    drawerOpen,
+    openDrawer,
+    setDrawerOpen,
+    handleImageUpdated,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #152

- `orders.tsx` の16個の独立した `useState` を3つのカスタムフックに分離し、状態の依存関係を明確化
- `useDebouncedSearch`: 汎用デバウンス検索フック（searchInput / searchDebounced のペア管理）
- `useOrderFilters`: フィルタ状態（shopDomain, year, priceMin, priceMax）+ ドロップダウン選択肢のDB読み込み
- `useOrderItems`: データ取得（requestIdパターン封じ込め）+ ソート状態 + ドロワー状態

## Design decisions

- **requestIdパターン維持**: `loadOrderItems()` はtauri-plugin-sql経由の非同期IPCでありAbortControllerでキャンセル不可のため
- **フィルタ値はstring型維持**: `<input>`/`<select>` バインドに自然。number変換はクエリ実行時に `parseNumericFilter()` で実施
- **sortBy/sortOrder はデータフック内**: データ再取得をトリガーするため表示設定ではなくデータ層に配置
- **viewMode/columnCount はローカル状態**: 純粋な表示制御で2変数のみ、フック化不要

## Test plan

- [x] `useDebouncedSearch` 単体テスト（8テスト）
- [x] `useOrderFilters` 単体テスト（7テスト）
- [x] `useOrderItems` 単体テスト（13テスト）
- [x] 既存 `orders.test.tsx` 統合テスト（17テスト）全パス
- [x] 全566テストパス、TypeScriptエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)