### PR TITLE
fix: 自動更新時に「更新」ボタンがちらつく問題を修正 (#192)

### DIFF
--- a/src/components/screens/logs.tsx
+++ b/src/components/screens/logs.tsx
@@ -28,9 +28,9 @@ export function Logs() {
   const [searchQuery, setSearchQuery] = useState('');
   const [autoRefresh, setAutoRefresh] = useState(false);
 
-  const loadLogs = async (level?: string) => {
+  const loadLogs = async (level?: string, isManual = false) => {
     try {
-      setLoading(true);
+      if (isManual) setLoading(true);
       const result = await invoke<LogEntry[]>('get_logs', {
         levelFilter: level || null,
         limit: 500,
@@ -40,7 +40,7 @@ export function Logs() {
       toastError(`ログの読み込みに失敗しました: ${formatError(err)}`);
       console.error('Failed to load logs:', err);
     } finally {
-      setLoading(false);
+      if (isManual) setLoading(false);
     }
   };
 
@@ -105,7 +105,7 @@ export function Logs() {
             {autoRefresh ? '自動更新中' : '自動更新'}
           </Button>
           <Button
-            onClick={() => loadLogs(filterLevel || undefined)}
+            onClick={() => loadLogs(filterLevel || undefined, true)}
             disabled={loading}
             aria-label="ログを手動で更新"
           >


### PR DESCRIPTION
## Summary

- `loadLogs` に `isManual = false` パラメータを追加
- `setLoading(true/false)` を `if (isManual)` で囲み、手動更新時のみ loading 状態を変化させる
- 手動「更新」ボタンの `onClick` から `isManual: true` で呼び出すよう変更
- `setInterval` からの自動呼び出しはデフォルトの `false` のままでボタンが静止

## Test plan

- [ ] アプリを起動してログビューワーを開く
- [ ] 「自動更新」を有効化し、「更新」ボタンが 2 秒ごとにちらつかないことを確認
- [ ] 「更新」ボタンを手動クリックしたとき「読み込み中...」に変わり、完了後「更新」に戻ることを確認

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)