### PR TITLE
fix: ホビーサーチ発送メールの複数注文同時発送に対応

### DIFF
--- a/src-tauri/src/parsers/hobbysearch/send.rs
+++ b/src-tauri/src/parsers/hobbysearch/send.rs
@@ -101,11 +101,11 @@ fn extract_order_sections(lines: &[&str]) -> Vec<(String, Vec<OrderItem>)> {
         Ok(p) => p,
         Err(_) => return Vec::new(),
     };
-    let price_pattern =
-        match Regex::new(r"単価：([\d,]+)円\s*×\s*個数：(\d+)\s*=\s*([\d,]+)円") {
-            Ok(p) => p,
-            Err(_) => return Vec::new(),
-        };
+    let price_pattern = match Regex::new(r"単価：([\d,]+)円\s*×\s*個数：(\d+)\s*=\s*([\d,]+)円")
+    {
+        Ok(p) => p,
+        Err(_) => return Vec::new(),
+    };
 
     let mut sections: Vec<(String, Vec<OrderItem>)> = Vec::new();
     let mut in_purchase_section = false;
@@ -142,8 +142,7 @@ fn extract_order_sections(lines: &[&str]) -> Vec<(String, Vec<OrderItem>)> {
             if let Some(num) = current_order_number.take() {
                 sections.push((num, std::mem::take(&mut current_items)));
             }
-            current_order_number =
-                Some(caps.get(1).unwrap().as_str().to_string());
+            current_order_number = Some(caps.get(1).unwrap().as_str().to_string());
             i += 1;
             continue;
         }
@@ -435,7 +434,10 @@ http://k2k.sagawa-exp.co.jp/p/sagawa/web/okurijoinput.jsp
 
         // 配送情報は両注文で共有される
         for order in &orders {
-            let delivery = order.delivery_info.as_ref().expect("delivery_info should be present");
+            let delivery = order
+                .delivery_info
+                .as_ref()
+                .expect("delivery_info should be present");
             assert_eq!(delivery.carrier, "佐川急便");
             assert_eq!(delivery.tracking_number, "999000111222");
         }


### PR DESCRIPTION
## Summary

- ホビーサーチの発送メールで複数注文が同時発送される場合、`[ご購入内容]` 内に複数の `[注文番号]` セクションが存在するが、従来は全商品を `[代表注文番号]` 配下の1注文にまとめてしまっていた
- `HobbySearchSendParser` に `parse_multi()` を実装し、`[注文番号]` セクションごとに個別の `OrderInfo` を返すよう対応
- 各注文は個別の商品リストを持ち、配送情報（運送会社・追跡番号等）は全注文で共有する
- `[注文番号]` セクションが存在しない場合は `None` を返し、従来の `parse()` にフォールバック（後方互換性維持）

## 修正前の問題

| 注文 | 修正前 | 修正後 |
|------|--------|--------|
| `[代表注文番号]`（1件目） | 全注文の商品が混入、配送情報付与 | 自注文の商品のみ、配送情報付与 ✅ |
| 2件目以降の `[注文番号]` | 配送情報が付かない | 配送情報付与 ✅ |

## Test plan

- [x] `test_parse_hobbysearch_send` — 既存テスト（`[注文番号]` なし、後方互換）通過
- [x] `test_parse_multi_returns_none_without_order_number_sections` — `[注文番号]` セクションなし → `None` 返却
- [x] `test_parse_multi_multiple_orders` — 複数注文の同時発送を正しく分割
- [x] `test_parse_multi_single_order_with_order_number_section` — 単一注文で `[注文番号]` あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)