### PR TITLE
feat: ダークモードのトグル機能を実装する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import { NavigationProvider } from '@/contexts/navigation-provider';
 import { useNavigation } from '@/contexts/use-navigation';
 import { SyncProvider } from '@/contexts/sync-provider';
 import { ParseProvider } from '@/contexts/parse-provider';
+import { ThemeProvider } from '@/contexts/theme-provider';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
@@ -192,13 +193,15 @@ function App() {
   }, []);
 
   return (
-    <NavigationProvider>
-      <SyncProvider>
-        <ParseProvider>
-          <AppContent />
-        </ParseProvider>
-      </SyncProvider>
-    </NavigationProvider>
+    <ThemeProvider>
+      <NavigationProvider>
+        <SyncProvider>
+          <ParseProvider>
+            <AppContent />
+          </ParseProvider>
+        </SyncProvider>
+      </NavigationProvider>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -15,6 +15,7 @@ import type { Screen } from '@/contexts/navigation-context-value';
 import type { ComponentType } from 'react';
 import { useState } from 'react';
 import { cn } from '@/lib/utils';
+import { ThemeToggle } from '@/components/ui/theme-toggle';
 
 /** サイドバーナビゲーションで表示する画面（Screen のサブセット） */
 type NavigationScreen = Extract<
@@ -199,6 +200,9 @@ export function Sidebar() {
           </div>
         </div>
       </nav>
+      <div className="p-3 border-t">
+        <ThemeToggle />
+      </div>
     </aside>
   );
 }

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,46 @@
+import { Sun, Moon, Monitor } from 'lucide-react';
+import { useTheme } from '@/contexts/use-theme';
+import type { Theme } from '@/contexts/theme-context-value';
+import { cn } from '@/lib/utils';
+
+type ThemeOption = {
+  value: Theme;
+  icon: typeof Sun;
+  label: string;
+};
+
+const options: ThemeOption[] = [
+  { value: 'light', icon: Sun, label: 'ライト' },
+  { value: 'dark', icon: Moon, label: 'ダーク' },
+  { value: 'system', icon: Monitor, label: 'システム' },
+];
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div
+      className="flex items-center gap-1 rounded-lg bg-muted/60 p-1"
+      role="group"
+      aria-label="テーマ切り替え"
+    >
+      {options.map(({ value, icon: Icon, label }) => (
+        <button
+          key={value}
+          onClick={() => setTheme(value)}
+          aria-pressed={theme === value}
+          aria-label={label}
+          title={label}
+          className={cn(
+            'flex flex-1 items-center justify-center rounded-md p-1.5 transition-colors',
+            theme === value
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <Icon className="h-3.5 w-3.5" />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/contexts/theme-context-value.ts
+++ b/src/contexts/theme-context-value.ts
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+
+export type Theme = 'light' | 'dark' | 'system';
+
+export type ThemeContextType = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+};
+
+export const ThemeContext = createContext<ThemeContextType | undefined>(
+  undefined
+);

--- a/src/contexts/theme-context.test.tsx
+++ b/src/contexts/theme-context.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { ThemeProvider } from './theme-provider';
+import { useTheme } from './use-theme';
+import type { ReactNode } from 'react';
+
+// jsdom は matchMedia を実装していないためモックする
+const mockMatchMedia = (matches: boolean) => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+};
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ThemeProvider>{children}</ThemeProvider>
+);
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    mockMatchMedia(false); // デフォルトはライトモード
+  });
+
+  it('localStorage に保存値がない場合、初期テーマは system', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    expect(result.current.theme).toBe('system');
+  });
+
+  it('localStorage に保存済みのテーマを復元する', () => {
+    localStorage.setItem('theme', 'dark');
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    expect(result.current.theme).toBe('dark');
+  });
+
+  it('setTheme("dark") で theme が dark になり localStorage に保存される', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    act(() => {
+      result.current.setTheme('dark');
+    });
+
+    expect(result.current.theme).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('setTheme("light") で html に dark クラスが付かない', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    act(() => {
+      result.current.setTheme('light');
+    });
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('setTheme("dark") で html に dark クラスが付く', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    act(() => {
+      result.current.setTheme('dark');
+    });
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('ThemeProvider 外で useTheme を呼ぶとエラーになる', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useTheme())).toThrow(
+      'useTheme must be used within a ThemeProvider'
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/contexts/theme-provider.tsx
+++ b/src/contexts/theme-provider.tsx
@@ -1,0 +1,46 @@
+import { useState, useEffect, type ReactNode } from 'react';
+import { type Theme, ThemeContext } from './theme-context-value';
+
+const STORAGE_KEY = 'theme';
+
+function getSystemTheme(): 'light' | 'dark' {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+}
+
+function applyTheme(theme: Theme): void {
+  const resolved = theme === 'system' ? getSystemTheme() : theme;
+  document.documentElement.classList.toggle('dark', resolved === 'dark');
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark' || stored === 'system')
+      return stored;
+    return 'system';
+  });
+
+  useEffect(() => {
+    applyTheme(theme);
+
+    if (theme !== 'system') return;
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = () => applyTheme('system');
+    media.addEventListener('change', handleChange);
+    return () => media.removeEventListener('change', handleChange);
+  }, [theme]);
+
+  const setTheme = (next: Theme) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    setThemeState(next);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/src/contexts/use-theme.ts
+++ b/src/contexts/use-theme.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { ThemeContext } from './theme-context-value';
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,9 @@
 
 @layer base {
   :root {
+    --scrollbar-track: 220 14.3% 93%;
+    --scrollbar-thumb: 220 13% 72%;
+    --scrollbar-thumb-hover: 220 13% 55%;
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;
@@ -32,6 +35,9 @@
   }
 
   .dark {
+    --scrollbar-track: 222.2 84% 7%;
+    --scrollbar-thumb: 215 27.9% 28%;
+    --scrollbar-thumb-hover: 215 27.9% 40%;
     --background: 222.2 84% 4.9%;
     --foreground: 210 40% 98%;
     --card: 222.2 84% 4.9%;
@@ -62,8 +68,25 @@
 @layer base {
   * {
     @apply border-border;
+    scrollbar-width: thin;
+    scrollbar-color: hsl(var(--scrollbar-thumb)) hsl(var(--scrollbar-track));
   }
   body {
     @apply bg-background text-foreground;
+  }
+  *::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  *::-webkit-scrollbar-track {
+    background: hsl(var(--scrollbar-track));
+    border-radius: 4px;
+  }
+  *::-webkit-scrollbar-thumb {
+    background: hsl(var(--scrollbar-thumb));
+    border-radius: 4px;
+  }
+  *::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--scrollbar-thumb-hover));
   }
 }


### PR DESCRIPTION
## Summary

- `ThemeProvider` / `useTheme` コンテキストを追加し、`<html>` に `dark` クラスを付け外し
- テーマ設定を `localStorage` に保存してリロード後も維持（キー: `theme`）
- `system` テーマ選択時は `prefers-color-scheme` メディアクエリに動的に連動
- サイドバー下部に Light / Dark / System の 3 択トグルボタン（`ThemeToggle`）を追加
- ダークモード時のスクロールバーを CSS 変数でテーマ連動スタイリング

## Closes

Closes #200

## Test plan

- [x] テーマコンテキストの 6 テストケースがすべて通ること (`theme-context.test.tsx`)
- [x] ライト ↔ ダーク ↔ システム を切り替えられること
- [x] ページリロード後も選択したテーマが維持されること
- [x] システムの `prefers-color-scheme` を dark に変えると自動でダークモードになること
- [x] ダークモード時のスクロールバーが背景に馴染んで目立たないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)