### PR TITLE
refactor: VendorPlugin レジストリ統合と不要コードの削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,77 @@ C:\Users\<ユーザー名>\AppData\Roaming\jp.github.hina0118.paa\client_secret.
 
 3. 認証を完了すると、トークンが自動的に保存され、次回以降は認証不要になります。
 
+## 新しい店舗（EC サイト）を追加する
+
+Phase 2 以降のプラグイン設計により、**変更箇所は最小限**で新店舗に対応できます。
+
+### 手順
+
+**1. パーサーモジュールを作成する**
+
+`src-tauri/src/parsers/<店舗名>/` ディレクトリを作成し、各メール種別のパーサーを実装します。
+各パーサーは `EmailParser` トレイトを実装してください。
+
+```
+src-tauri/src/parsers/<店舗名>/
+  mod.rs
+  confirm.rs         ← 注文確認メール
+  send.rs            ← 発送完了メール
+  cancel.rs          ← キャンセルメール
+  （必要に応じて追加）
+```
+
+**2. プラグインを実装する**
+
+`src-tauri/src/plugins/<店舗名>.rs` を作成し、`VendorPlugin` トレイトを実装します。
+
+```rust
+pub struct NewShopPlugin;
+
+impl VendorPlugin for NewShopPlugin {
+    fn parser_types(&self) -> &[&str] {
+        &["newshop_confirm", "newshop_send", "newshop_cancel"]
+    }
+
+    fn priority(&self) -> i32 { 10 }
+
+    fn shop_name(&self) -> &str { "新店舗名" }
+
+    fn get_parser(&self, parser_type: &str) -> Option<Box<dyn EmailParser>> { ... }
+
+    fn default_shop_settings(&self) -> Vec<DefaultShopSetting> {
+        // 送信元アドレス・件名フィルター・parser_type のデフォルト設定を返す
+        // アプリ起動時に DB へ自動挿入される（INSERT OR IGNORE）
+        vec![ ... ]
+    }
+
+    async fn dispatch(&self, parser_type: &str, ...) -> Result<DispatchOutcome, DispatchError> { ... }
+}
+```
+
+**3. `registry.rs` に 1 行追加する**
+
+```rust
+// src-tauri/src/plugins/registry.rs
+pub fn build_registry() -> Vec<Box<dyn VendorPlugin>> {
+    vec![
+        Box::new(DmmPlugin),
+        Box::new(HobbySearchPlugin),
+        Box::new(NewShopPlugin),  // ← ここだけ追加
+    ]
+}
+```
+
+**4. 動作確認する**
+
+```bash
+cargo test
+```
+
+アプリを起動すると `ensure_default_settings()` が自動実行され、`default_shop_settings()` で定義したレコードが `shop_settings` テーブルへ挿入されます。SQL ファイルの編集は不要です。
+
+---
+
 ## 開発用コマンド
 
 ### アプリケーションの起動

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -7,11 +7,6 @@ use crate::repository::{
     SqliteMiscStatsRepository, SqliteOrderStatsRepository, SqliteProductMasterStatsRepository,
 };
 
-#[tauri::command]
-pub fn greet(name: &str) -> String {
-    format!("Hello, {name}! You've been greeted from Rust!")
-}
-
 /// E2E モード時に DB シードを実行。フロントエンドのマウント後に呼ぶ（マイグレーション完了後）
 #[tauri::command]
 pub async fn seed_e2e_db(pool: tauri::State<'_, SqlitePool>) -> Result<(), String> {
@@ -72,24 +67,6 @@ pub async fn get_misc_stats(pool: tauri::State<'_, SqlitePool>) -> Result<MiscSt
 mod tests {
     use super::*;
     use serial_test::serial;
-
-    #[test]
-    fn test_greet() {
-        let result = greet("World");
-        assert_eq!(result, "Hello, World! You've been greeted from Rust!");
-    }
-
-    #[test]
-    fn test_greet_empty() {
-        let result = greet("");
-        assert_eq!(result, "Hello, ! You've been greeted from Rust!");
-    }
-
-    #[test]
-    fn test_greet_special_characters() {
-        let result = greet("世界");
-        assert_eq!(result, "Hello, 世界! You've been greeted from Rust!");
-    }
 
     #[test]
     #[serial]

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -20,18 +20,6 @@ pub fn validate_window_size(width: i64, height: i64) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub async fn get_window_settings(
-    app_handle: tauri::AppHandle,
-) -> Result<config::WindowConfig, String> {
-    let app_config_dir = app_handle
-        .path()
-        .app_config_dir()
-        .map_err(|e| format!("Failed to get app config dir: {e}"))?;
-    let config = config::load(&app_config_dir)?;
-    Ok(config.window)
-}
-
-#[tauri::command]
 pub async fn save_window_settings(
     app_handle: tauri::AppHandle,
     width: i64,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -429,7 +429,6 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            commands::greet,
             commands::seed_e2e_db,
             commands::get_db_filename,
             commands::fetch_gmail_emails,
@@ -442,7 +441,6 @@ pub fn run() {
             commands::update_timeout_minutes,
             commands::reset_sync_status,
             commands::reset_sync_date,
-            commands::get_window_settings,
             commands::save_window_settings,
             commands::get_email_stats,
             commands::get_order_stats,

--- a/src-tauri/src/logic/email_parser.rs
+++ b/src-tauri/src/logic/email_parser.rs
@@ -4,43 +4,21 @@
 //! 外部依存を持たないため、テストが容易です。
 
 use crate::logic::sync_logic::extract_email_address;
-use crate::parsers::{EmailParser, OrderInfo};
+use crate::plugins::{build_registry, find_plugin};
 
 /// パーサータイプ名からパーサーが存在するかチェックする
+///
+/// プラグインレジストリを参照するため、新店舗を registry.rs に追加するだけで
+/// 自動的にバリデーション対象に含まれる。
 ///
 /// # Arguments
 /// * `parser_type` - パーサータイプ名
 ///
 /// # Returns
-/// パーサーが存在する場合はtrue
+/// レジストリにプラグインが存在する場合は true
 pub fn is_valid_parser_type(parser_type: &str) -> bool {
-    matches!(
-        parser_type,
-        "hobbysearch_confirm"
-            | "hobbysearch_confirm_yoyaku"
-            | "hobbysearch_change"
-            | "hobbysearch_change_yoyaku"
-            | "hobbysearch_send"
-            | "hobbysearch_cancel"
-            | "dmm_confirm"
-            | "dmm_send"
-            | "dmm_cancel"
-            | "dmm_order_number_change"
-            | "dmm_merge_complete"
-            | "dmm_split_complete"
-    )
-}
-
-/// パースを試行し、結果を返す
-///
-/// # Arguments
-/// * `parser` - パーサーインスタンス
-/// * `email_body` - メール本文
-///
-/// # Returns
-/// パース結果
-pub fn try_parse(parser: &dyn EmailParser, email_body: &str) -> Result<OrderInfo, String> {
-    parser.parse(email_body)
+    let registry = build_registry();
+    find_plugin(&registry, parser_type).is_some()
 }
 
 /// 送信者アドレスと件名からパーサータイプの候補を取得する
@@ -146,57 +124,18 @@ mod tests {
     // ==================== is_valid_parser_type Tests ====================
 
     #[test]
-    fn test_is_valid_parser_type_hobbysearch_confirm() {
+    fn test_is_valid_parser_type_known_types_return_true() {
+        // レジストリに登録済みの代表的な parser_type は true を返す
+        assert!(is_valid_parser_type("dmm_confirm"));
+        assert!(is_valid_parser_type("dmm_cancel"));
+        assert!(is_valid_parser_type("dmm_split_complete"));
         assert!(is_valid_parser_type("hobbysearch_confirm"));
-    }
-
-    #[test]
-    fn test_is_valid_parser_type_hobbysearch_confirm_yoyaku() {
-        assert!(is_valid_parser_type("hobbysearch_confirm_yoyaku"));
-    }
-
-    #[test]
-    fn test_is_valid_parser_type_hobbysearch_change() {
-        assert!(is_valid_parser_type("hobbysearch_change"));
-    }
-
-    #[test]
-    fn test_is_valid_parser_type_hobbysearch_change_yoyaku() {
-        assert!(is_valid_parser_type("hobbysearch_change_yoyaku"));
-    }
-
-    #[test]
-    fn test_is_valid_parser_type_hobbysearch_send() {
-        assert!(is_valid_parser_type("hobbysearch_send"));
-    }
-
-    #[test]
-    fn test_is_valid_parser_type_hobbysearch_cancel() {
         assert!(is_valid_parser_type("hobbysearch_cancel"));
     }
 
     #[test]
-    fn test_is_valid_parser_type_unknown() {
+    fn test_is_valid_parser_type_unknown_returns_false() {
         assert!(!is_valid_parser_type("unknown_parser"));
-    }
-
-    #[test]
-    fn test_is_valid_parser_type_dmm_confirm() {
-        assert!(is_valid_parser_type("dmm_confirm"));
-    }
-
-    #[test]
-    fn test_is_valid_parser_type_dmm_cancel() {
-        assert!(is_valid_parser_type("dmm_cancel"));
-    }
-
-    #[test]
-    fn test_is_valid_parser_type_dmm_split_complete() {
-        assert!(is_valid_parser_type("dmm_split_complete"));
-    }
-
-    #[test]
-    fn test_is_valid_parser_type_empty() {
         assert!(!is_valid_parser_type(""));
     }
 


### PR DESCRIPTION
## Summary

- `is_valid_parser_type()` をハードコードリストからレジストリ参照 (`build_registry()` + `find_plugin()`) に変更。新店舗追加時にバリデーション対象が自動更新されるよう修正（Issue #182/#183 対応）
- 未使用の `try_parse()` 関数と関連 import を削除（デッドコード除去）
- `greet` コマンド（Tauri テンプレートの残骸）とそのテスト3件を削除
- `get_window_settings` コマンドを削除（ウィンドウ復元は `lib.rs` 起動時処理で完結しており、フロントエンドからの読み取りは不要）
- README に新店舗追加手順（4ステップ）を追記

## Test plan

- [x] `cargo test --lib` が全件 pass することを確認（492 tests）
- [x] ウィンドウサイズの保存・復元が正常に動作することを確認
- [x] 既存の shop_settings バリデーションが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)