### PR TITLE
feat: キッズドラゴン注文確認・発送通知パーサーを追加する (#212, #213)

### DIFF
--- a/src-tauri/src/plugins/kids_dragon/mod.rs
+++ b/src-tauri/src/plugins/kids_dragon/mod.rs
@@ -1,0 +1,119 @@
+//! キッズドラゴン（HOBBY SHOP キッズドラゴン）プラグイン
+//!
+//! おちゃのこネット（www41.ocnk.net）経由で配信されるメールをパースする。
+//! 送信元アドレス `satiusukurukuru@yahoo.co.jp` から届く注文確認・発送通知に対応する。
+
+pub mod parsers;
+
+use async_trait::async_trait;
+
+use crate::parsers::EmailParser;
+use crate::repository::SqliteOrderRepository;
+
+use super::{
+    derive_shop_domain, DefaultShopSetting, DispatchError, DispatchOutcome, PluginRegistration,
+    VendorPlugin,
+};
+
+pub struct KidsDragonPlugin;
+
+#[async_trait]
+impl VendorPlugin for KidsDragonPlugin {
+    fn parser_types(&self) -> &[&str] {
+        &["kids_dragon_confirm", "kids_dragon_send"]
+    }
+
+    fn priority(&self) -> i32 {
+        10
+    }
+
+    fn get_parser(&self, parser_type: &str) -> Option<Box<dyn EmailParser>> {
+        match parser_type {
+            "kids_dragon_confirm" => Some(Box::new(parsers::confirm::KidsDragonConfirmParser)),
+            "kids_dragon_send" => Some(Box::new(parsers::send::KidsDragonSendParser)),
+            _ => None,
+        }
+    }
+
+    fn shop_name(&self) -> &str {
+        "キッズドラゴン"
+    }
+
+    fn default_shop_settings(&self) -> Vec<DefaultShopSetting> {
+        vec![
+            DefaultShopSetting {
+                shop_name: "キッズドラゴン".to_string(),
+                sender_address: "satiusukurukuru@yahoo.co.jp".to_string(),
+                parser_type: "kids_dragon_confirm".to_string(),
+                subject_filters: Some(vec![
+                    "ご注文有難うございます　キッズドラゴンです".to_string()
+                ]),
+            },
+            DefaultShopSetting {
+                shop_name: "キッズドラゴン".to_string(),
+                sender_address: "satiusukurukuru@yahoo.co.jp".to_string(),
+                parser_type: "kids_dragon_send".to_string(),
+                subject_filters: Some(vec!["発送が完了致しました".to_string()]),
+            },
+        ]
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch(
+        &self,
+        parser_type: &str,
+        email_id: i64,
+        from_address: Option<&str>,
+        shop_name: &str,
+        _internal_date: Option<i64>,
+        body: &str,
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    ) -> Result<DispatchOutcome, DispatchError> {
+        let shop_domain = derive_shop_domain(from_address);
+
+        // parser は同期処理のみ。await をまたがないようブロックで即 drop する。
+        let order_info = {
+            let parser = self.get_parser(parser_type).ok_or_else(|| {
+                DispatchError::ParseFailed(format!("No parser for type: {}", parser_type))
+            })?;
+            parser.parse(body).map_err(DispatchError::ParseFailed)?
+        };
+
+        log::debug!(
+            "[{}] email_id={} order_number={}",
+            parser_type,
+            email_id,
+            order_info.order_number
+        );
+
+        let order_id = SqliteOrderRepository::save_order_in_tx(
+            tx,
+            &order_info,
+            Some(email_id),
+            shop_domain,
+            Some(shop_name.to_string()),
+        )
+        .await
+        .map_err(DispatchError::SaveFailed)?;
+
+        // 発送通知は発送時の商品リストが最終状態のため、既存アイテムを置き換える。
+        // 注文確認（confirm）より商品が増減している場合（分割発送等）に対応する。
+        if parser_type == "kids_dragon_send" {
+            SqliteOrderRepository::replace_items_for_order_in_tx(tx, order_id, &order_info)
+                .await
+                .map_err(DispatchError::SaveFailed)?;
+
+            log::debug!(
+                "[kids_dragon_send] Replaced items for order_id={} (order_number={})",
+                order_id,
+                order_info.order_number
+            );
+        }
+
+        Ok(DispatchOutcome::OrderSaved(Box::new(order_info)))
+    }
+}
+
+inventory::submit!(PluginRegistration {
+    factory: || Box::new(KidsDragonPlugin),
+});

--- a/src-tauri/src/plugins/kids_dragon/parsers/confirm.rs
+++ b/src-tauri/src/plugins/kids_dragon/parsers/confirm.rs
@@ -1,0 +1,147 @@
+use super::{extract_amounts, extract_order_date, parse_item_line};
+use crate::parsers::{EmailParser, OrderInfo};
+
+/// キッズドラゴン 注文確認メール用パーサー
+///
+/// キッズドラゴンの注文確認メールには注文番号フィールドが存在しないため、
+/// 受注日時（`YYYY-MM-DD HH:MM` 形式）を `order_number` として使用する。
+pub struct KidsDragonConfirmParser;
+
+impl EmailParser for KidsDragonConfirmParser {
+    fn parse(&self, email_body: &str) -> Result<OrderInfo, String> {
+        let lines: Vec<&str> = email_body.lines().collect();
+
+        let items: Vec<_> = lines
+            .iter()
+            .filter_map(|line| parse_item_line(line))
+            .collect();
+
+        if items.is_empty() {
+            return Err("No items found".to_string());
+        }
+
+        let (subtotal, shipping_fee, total_amount) = extract_amounts(&lines);
+
+        let order_date =
+            extract_order_date(&lines).ok_or("Order date not found (used as order number)")?;
+
+        Ok(OrderInfo {
+            order_number: order_date.clone(),
+            order_date: Some(order_date),
+            delivery_address: None,
+            delivery_info: None,
+            items,
+            subtotal,
+            shipping_fee,
+            total_amount,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// サンプル確認メール（sample/原田裕基様 ご注文有難うございます キッズドラゴンです.eml の
+    /// UTF-8 デコード後の本文。全角コロン `：` を含む実際のフォーマットを使用する）
+    fn sample_confirm_email() -> &'static str {
+        r#"【ご注文ご確認メール】  ホビーショップ　キッズドラゴン
+
+[商品名]：バンダイ ノンスケール ＳＤ ＥＸ-スタンダードシリーズ No.004 XXXG-00W0 ウィングガンダムゼロ ＥＷ[bd-sdex-004]       594 円 x  1 個       594 円
+[商品名]：バンダイ ビルダーズ パーツ ＨＤ ノンスケール ＭＳパネル ０１[bd-sdcs-019]       550 円 x  1 個       550 円
+[商品名]：コトブキヤ ウェポンユニット MW-035 エネルギーシールド[wu-mw-35]       660 円 x  1 個       660 円
+[商品名]：バンダイ 30MS OB-12 オプションボディパーツ アームパーツ＆レッグパーツ［ホワイト/ブラック］[bd-30ms-ob012]       990 円 x  1 個       990 円
+[商品名]：バンダイ 30MS OB-11 オプションボディパーツ アームパーツ&レッグパーツ[カラーC][bd-30ms-ob11]       880 円 x  1 個       880 円
+[商品名]：バンダイ ノンスケール 30MM W-09 オプションパーツセット 3[bd-30mm-w09]       594 円 x  1 個       594 円
+  商品小計             4,268 円
+  送料                   1,200 円
+  商品合計             4,268 円
+  送料合計             1,200 円
+  合計                   5,468 円
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+○ お支払いについて
+
+  金額        : 5,468 円
+  方法        : 銀行振込
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+○ 受注日時
+  2023年6月15日 02:17
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+"#
+    }
+
+    #[test]
+    fn test_parse_confirm_item_count() {
+        let order = KidsDragonConfirmParser
+            .parse(sample_confirm_email())
+            .unwrap();
+        assert_eq!(order.items.len(), 6);
+    }
+
+    #[test]
+    fn test_parse_confirm_first_item() {
+        let order = KidsDragonConfirmParser
+            .parse(sample_confirm_email())
+            .unwrap();
+        let item = &order.items[0];
+        assert!(item.name.contains("ウィングガンダムゼロ"));
+        assert_eq!(item.model_number, Some("bd-sdex-004".to_string()));
+        assert_eq!(item.unit_price, 594);
+        assert_eq!(item.quantity, 1);
+        assert_eq!(item.subtotal, 594);
+    }
+
+    #[test]
+    fn test_parse_confirm_item_with_brackets_in_name() {
+        // 商品名に [カラーC] を含む場合でも SKU が正しく抽出される
+        let order = KidsDragonConfirmParser
+            .parse(sample_confirm_email())
+            .unwrap();
+        let item = &order.items[4]; // bd-30ms-ob11
+        assert!(item.name.contains("[カラーC]"));
+        assert_eq!(item.model_number, Some("bd-30ms-ob11".to_string()));
+        assert_eq!(item.unit_price, 880);
+    }
+
+    #[test]
+    fn test_parse_confirm_amounts() {
+        let order = KidsDragonConfirmParser
+            .parse(sample_confirm_email())
+            .unwrap();
+        assert_eq!(order.subtotal, Some(4268));
+        assert_eq!(order.shipping_fee, Some(1200));
+        assert_eq!(order.total_amount, Some(5468));
+    }
+
+    #[test]
+    fn test_parse_confirm_order_date_as_order_number() {
+        let order = KidsDragonConfirmParser
+            .parse(sample_confirm_email())
+            .unwrap();
+        assert_eq!(order.order_date, Some("2023-06-15 02:17".to_string()));
+        assert_eq!(order.order_number, "2023-06-15 02:17");
+    }
+
+    #[test]
+    fn test_parse_confirm_no_delivery_info() {
+        let order = KidsDragonConfirmParser
+            .parse(sample_confirm_email())
+            .unwrap();
+        assert!(order.delivery_info.is_none());
+    }
+
+    #[test]
+    fn test_parse_confirm_no_items_returns_error() {
+        let result = KidsDragonConfirmParser.parse("本文なし\n2023年6月15日 02:17");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_confirm_no_date_returns_error() {
+        let body = "[商品名]:テスト商品[sku-001]       594 円 x  1 個       594 円\n";
+        let result = KidsDragonConfirmParser.parse(body);
+        assert!(result.is_err());
+    }
+}

--- a/src-tauri/src/plugins/kids_dragon/parsers/mod.rs
+++ b/src-tauri/src/plugins/kids_dragon/parsers/mod.rs
@@ -1,0 +1,216 @@
+use crate::parsers::OrderItem;
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+pub mod confirm;
+pub mod send;
+
+/// `[商品名]：商品名[SKU]       単価 円 x  個数 個       合計 円` 形式の行パターン
+///
+/// コロンは全角（`：` U+FF1A）・半角（`:` U+003A）両方に対応する。
+/// ISO-2022-JP 由来のメールは全角コロンで届く場合がある。
+///
+/// `.+` をグリーディにすることで、商品名に `[カラーC]` 等のブラケットが含まれる場合でも
+/// SKU（末尾の最後のブラケット）を正しく抽出できる。
+static ITEM_LINE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^\[商品名\][：:](.+)\[([^\]]+)\]\s+([\d,]+)\s*円\s+x\s+(\d+)\s*個\s+([\d,]+)\s*円")
+        .expect("Invalid ITEM_LINE_RE")
+});
+
+/// `YYYY年M月D日 HH:MM` 形式の受注日時パターン
+static ORDER_DATE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(\d{4})年(\d+)月(\d+)日\s+(\d{1,2}:\d{2})").expect("Invalid ORDER_DATE_RE")
+});
+
+/// 金額抽出用パターン（`N,NNN 円` 形式）
+static AMOUNT_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"([\d,]+)\s*円").expect("Invalid AMOUNT_RE"));
+
+/// `[商品名]:...` 行から OrderItem を抽出する
+///
+/// 商品名に `[xxx]` 形式のブラケットが含まれる場合も対応（末尾ブラケットを SKU とみなす）。
+pub fn parse_item_line(line: &str) -> Option<OrderItem> {
+    let caps = ITEM_LINE_RE.captures(line)?;
+    let name = caps[1].trim().to_string();
+    let model_number = Some(caps[2].to_string());
+    let unit_price = caps[3].replace(',', "").parse::<i64>().ok()?;
+    let quantity = caps[4].parse::<i64>().ok()?;
+    let subtotal = caps[5].replace(',', "").parse::<i64>().ok()?;
+
+    Some(OrderItem {
+        name,
+        manufacturer: None,
+        model_number,
+        unit_price,
+        quantity,
+        subtotal,
+        image_url: None,
+    })
+}
+
+/// 商品小計・送料・合計を抽出する
+///
+/// `商品合計` / `送料合計` は集計行であるため除外する。
+pub fn extract_amounts(lines: &[&str]) -> (Option<i64>, Option<i64>, Option<i64>) {
+    let mut subtotal = None;
+    let mut shipping_fee = None;
+    let mut total_amount = None;
+
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.starts_with("商品小計") {
+            subtotal = parse_amount(trimmed);
+        } else if trimmed.starts_with("送料") && !trimmed.starts_with("送料合計") {
+            shipping_fee = parse_amount(trimmed);
+        } else if trimmed.starts_with("合計") {
+            total_amount = parse_amount(trimmed);
+        }
+    }
+
+    (subtotal, shipping_fee, total_amount)
+}
+
+/// 受注日時を `"YYYY-MM-DD HH:MM"` 形式で抽出する
+///
+/// 本文中の `YYYY年M月D日 HH:MM` パターンを探して返す。
+pub fn extract_order_date(lines: &[&str]) -> Option<String> {
+    for line in lines {
+        if let Some(caps) = ORDER_DATE_RE.captures(line) {
+            let year = &caps[1];
+            let month: u32 = caps[2].parse().ok()?;
+            let day: u32 = caps[3].parse().ok()?;
+            let time = &caps[4];
+            return Some(format!("{}-{:02}-{:02} {}", year, month, day, time));
+        }
+    }
+    None
+}
+
+fn parse_amount(line: &str) -> Option<i64> {
+    AMOUNT_RE
+        .captures(line)
+        .and_then(|caps| caps[1].replace(',', "").parse::<i64>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_item_line_fullwidth_colon() {
+        // 実際のメールは全角コロン `：`（U+FF1A）
+        let line = "[商品名]：バンダイ ノンスケール ＳＤ ＥＸ-スタンダードシリーズ No.004 ウィングガンダムゼロ ＥＷ[bd-sdex-004]       594 円 x  1 個       594 円";
+        let item = parse_item_line(line).unwrap();
+        assert!(item.name.contains("ウィングガンダムゼロ"));
+        assert_eq!(item.model_number, Some("bd-sdex-004".to_string()));
+        assert_eq!(item.unit_price, 594);
+        assert_eq!(item.quantity, 1);
+        assert_eq!(item.subtotal, 594);
+    }
+
+    #[test]
+    fn test_parse_item_line_halfwidth_colon() {
+        // 半角コロン `:` にも対応（後方互換）
+        let line = "[商品名]:バンダイ ノンスケール SD EX ウィングガンダムゼロ EW[bd-sdex-004]       594 円 x  1 個       594 円";
+        let item = parse_item_line(line).unwrap();
+        assert_eq!(item.model_number, Some("bd-sdex-004".to_string()));
+        assert_eq!(item.unit_price, 594);
+    }
+
+    #[test]
+    fn test_parse_item_line_brackets_in_name() {
+        // 商品名に [カラーC] を含むケース（全角コロン）
+        let line = "[商品名]：バンダイ 30MS OB-11 アームパーツ&レッグパーツ[カラーC][bd-30ms-ob11]       880 円 x  1 個       880 円";
+        let item = parse_item_line(line).unwrap();
+        assert!(item.name.contains("[カラーC]"));
+        assert_eq!(item.model_number, Some("bd-30ms-ob11".to_string()));
+        assert_eq!(item.unit_price, 880);
+    }
+
+    #[test]
+    fn test_parse_item_line_fullwidth_brackets_in_name() {
+        // 全角ブラケット ［ホワイト/ブラック］ を含む商品名（全角コロン）
+        let line = "[商品名]：バンダイ 30MS OB-12 アームパーツ＆レッグパーツ［ホワイト/ブラック］[bd-30ms-ob012]       990 円 x  1 個       990 円";
+        let item = parse_item_line(line).unwrap();
+        assert!(item.name.contains("［ホワイト/ブラック］"));
+        assert_eq!(item.model_number, Some("bd-30ms-ob012".to_string()));
+        assert_eq!(item.unit_price, 990);
+    }
+
+    #[test]
+    fn test_parse_item_line_with_comma_price() {
+        let line = "[商品名]：テスト商品[test-001]       1,980 円 x  2 個       3,960 円";
+        let item = parse_item_line(line).unwrap();
+        assert_eq!(item.unit_price, 1980);
+        assert_eq!(item.quantity, 2);
+        assert_eq!(item.subtotal, 3960);
+    }
+
+    #[test]
+    fn test_parse_item_line_not_matching() {
+        assert!(parse_item_line("普通のテキスト行").is_none());
+        assert!(parse_item_line("  商品小計  4,268 円").is_none());
+    }
+
+    #[test]
+    fn test_extract_amounts_all() {
+        let lines = vec![
+            "  商品小計             4,268 円",
+            "  送料                   1,200 円",
+            "  商品合計             4,268 円",
+            "  送料合計             1,200 円",
+            "  合計                   5,468 円",
+        ];
+        let (subtotal, shipping, total) = extract_amounts(&lines);
+        assert_eq!(subtotal, Some(4268));
+        assert_eq!(shipping, Some(1200));
+        assert_eq!(total, Some(5468));
+    }
+
+    #[test]
+    fn test_extract_amounts_excludes_aggregate_lines() {
+        // 商品合計・送料合計は subtotal / shipping に入らない
+        let lines = vec![
+            "  商品合計             4,268 円",
+            "  送料合計             1,200 円",
+        ];
+        let (subtotal, shipping, total) = extract_amounts(&lines);
+        assert_eq!(subtotal, None);
+        assert_eq!(shipping, None);
+        assert_eq!(total, None);
+    }
+
+    #[test]
+    fn test_extract_order_date() {
+        let lines = vec!["★ 受注日時", "  2023年6月15日 02:17"];
+        assert_eq!(
+            extract_order_date(&lines),
+            Some("2023-06-15 02:17".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_order_date_inline() {
+        // セクションヘッダと同じ行にある場合
+        let lines = vec!["★ 受注日時  2023年6月15日 02:17"];
+        assert_eq!(
+            extract_order_date(&lines),
+            Some("2023-06-15 02:17".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_order_date_single_digit_month() {
+        let lines = vec!["  2023年1月5日 09:03"];
+        assert_eq!(
+            extract_order_date(&lines),
+            Some("2023-01-05 09:03".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_order_date_not_found() {
+        let lines = vec!["注文確認メール", "キッズドラゴンです"];
+        assert_eq!(extract_order_date(&lines), None);
+    }
+}

--- a/src-tauri/src/plugins/kids_dragon/parsers/send.rs
+++ b/src-tauri/src/plugins/kids_dragon/parsers/send.rs
@@ -1,0 +1,119 @@
+use super::{extract_amounts, extract_order_date, parse_item_line};
+use crate::parsers::{EmailParser, OrderInfo};
+
+/// キッズドラゴン 発送通知メール用パーサー
+///
+/// confirm と同一の商品行フォーマットを使用する。
+/// 発送通知には追跡番号が含まれないため `delivery_info` は設定しない。
+/// 分割発送の場合、発送通知の商品リストは注文確認より少なくなる場合がある。
+pub struct KidsDragonSendParser;
+
+impl EmailParser for KidsDragonSendParser {
+    fn parse(&self, email_body: &str) -> Result<OrderInfo, String> {
+        let lines: Vec<&str> = email_body.lines().collect();
+
+        let items: Vec<_> = lines
+            .iter()
+            .filter_map(|line| parse_item_line(line))
+            .collect();
+
+        if items.is_empty() {
+            return Err("No items found".to_string());
+        }
+
+        let (subtotal, shipping_fee, total_amount) = extract_amounts(&lines);
+
+        let order_date =
+            extract_order_date(&lines).ok_or("Order date not found (used as order number)")?;
+
+        Ok(OrderInfo {
+            order_number: order_date.clone(),
+            order_date: Some(order_date),
+            delivery_address: None,
+            delivery_info: None, // 追跡番号なし
+            items,
+            subtotal,
+            shipping_fee,
+            total_amount,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// サンプル発送通知メール（sample/商品の発送が完了致しました.eml の
+    /// UTF-8 デコード後の本文。全角コロン `：` を含む実際のフォーマットを使用する）
+    fn sample_send_email() -> &'static str {
+        r#"商品の発送が完了致しました
+
+ホビーショップ　キッズドラゴン
+
+[商品名]：バンダイ ビルダーズ パーツ ＨＤ ノンスケール ＭＳパネル ０１[bd-sdcs-019]       550 円 x  1 個       550 円
+[商品名]：コトブキヤ ウェポンユニット MW-035 エネルギーシールド[wu-mw-35]       660 円 x  1 個       660 円
+  商品小計             2,684 円
+  送料                   1,200 円
+  商品合計             2,684 円
+  送料合計             1,200 円
+  合計                   3,884 円
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+○ 送り主、お届け先情報
+
+  送り主    : ＨＯＢＢＹ ＳＨＯＰ キッズドラゴン
+  発送方法  : ヤマト宅急便
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+○ 受注日時
+  2023年6月15日 02:17
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+"#
+    }
+
+    #[test]
+    fn test_parse_send_item_count() {
+        let order = KidsDragonSendParser.parse(sample_send_email()).unwrap();
+        // 分割発送のため注文確認より少ない 2 商品
+        assert_eq!(order.items.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_send_first_item() {
+        let order = KidsDragonSendParser.parse(sample_send_email()).unwrap();
+        let item = &order.items[0];
+        assert!(item.name.contains("ＭＳパネル"));
+        assert_eq!(item.model_number, Some("bd-sdcs-019".to_string()));
+        assert_eq!(item.unit_price, 550);
+        assert_eq!(item.quantity, 1);
+        assert_eq!(item.subtotal, 550);
+    }
+
+    #[test]
+    fn test_parse_send_amounts() {
+        let order = KidsDragonSendParser.parse(sample_send_email()).unwrap();
+        assert_eq!(order.subtotal, Some(2684));
+        assert_eq!(order.shipping_fee, Some(1200));
+        assert_eq!(order.total_amount, Some(3884));
+    }
+
+    #[test]
+    fn test_parse_send_order_date_as_order_number() {
+        let order = KidsDragonSendParser.parse(sample_send_email()).unwrap();
+        assert_eq!(order.order_date, Some("2023-06-15 02:17".to_string()));
+        assert_eq!(order.order_number, "2023-06-15 02:17");
+    }
+
+    #[test]
+    fn test_parse_send_no_delivery_info() {
+        // 追跡番号なし
+        let order = KidsDragonSendParser.parse(sample_send_email()).unwrap();
+        assert!(order.delivery_info.is_none());
+    }
+
+    #[test]
+    fn test_parse_send_no_items_returns_error() {
+        let result = KidsDragonSendParser.parse("本文なし\n2023年6月15日 02:17");
+        assert!(result.is_err());
+    }
+}

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -11,6 +11,7 @@
 // pub mod にすることでリンカーがモジュールを保持し、inventory::submit! の静的初期化が LTO でも除外されない
 pub mod dmm;
 pub mod hobbysearch;
+pub mod kids_dragon;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // inventory による自動登録


### PR DESCRIPTION
## 概要

- Closes #212
- Closes #213

キッズドラゴン（HOBBY SHOP キッズドラゴン）の注文確認メール・発送通知メールのパーサーを追加する。

## 新構造

既存の `parsers/dmm/`・`parsers/hobbysearch/` とは異なり、パーサーをプラグイン配下に配置する新構造を採用。

```
plugins/kids_dragon/
  mod.rs              ← KidsDragonPlugin（VendorPlugin）
  parsers/
    mod.rs            ← 共有ヘルパー（parse_item_line / extract_amounts / extract_order_date）
    confirm.rs        ← KidsDragonConfirmParser
    send.rs           ← KidsDragonSendParser
```

## 主な実装ポイント

- **全角コロン対応**: `[商品名]：` の `：`（U+FF1A）と `:` の両方にマッチ（ISO-2022-JP 由来）
- **order_number**: 注文番号フィールドがないため受注日時（`YYYY-MM-DD HH:MM`）を代替使用
- **SKU抽出**: グリーディマッチで `[カラーC][bd-30ms-ob11]` のような商品名内ブラケット混在に対応
- **発送時の商品調整**: `kids_dragon_send` は `replace_items_for_order_in_tx` で既存アイテムを発送時の状態に上書き（分割発送・増減に対応）
- **件名フィルター**: confirm=`ご注文有難うございます　キッズドラゴンです`、send=`発送が完了致しました`

## テスト計画

- [x] `cargo test` 全通過（521 passed）
- [x] `cargo fmt` 適用済み
- [x] `cargo clippy` 警告なし
- [x] 全角コロン・全角ブラケット混在のケースをユニットテストで網羅

🤖 Generated with [Claude Code](https://claude.com/claude-code)