### PR TITLE
refactor: 日本郵便追跡 URL 定数を plugins/mod.rs に共通化

### DIFF
--- a/src-tauri/src/plugins/animate/parsers/send.rs
+++ b/src-tauri/src/plugins/animate/parsers/send.rs
@@ -1,9 +1,6 @@
 use super::{body_to_lines, extract_items, extract_order_number, extract_tracking_number};
 use crate::parsers::{DeliveryInfo, EmailParser, OrderInfo};
-
-/// ゆうパック追跡サービスの URL
-const JAPANPOST_TRACKING_URL: &str =
-    "https://trackings.post.japanpost.jp/services/srv/search/input";
+use crate::plugins::JAPANPOST_TRACKING_URL;
 
 /// アニメイト通販 出荷完了メール用パーサー
 ///
@@ -133,7 +130,7 @@ TEL：000-0000-0000
         let delivery = order.delivery_info.unwrap();
         assert_eq!(
             delivery.carrier_url,
-            Some("https://trackings.post.japanpost.jp/services/srv/search/input".to_string())
+            Some(crate::plugins::JAPANPOST_TRACKING_URL.to_string())
         );
     }
 

--- a/src-tauri/src/plugins/furuichi_online/parsers/send.rs
+++ b/src-tauri/src/plugins/furuichi_online/parsers/send.rs
@@ -2,10 +2,7 @@ use super::{
     body_to_lines, extract_carrier, extract_items, extract_order_number, extract_tracking_number,
 };
 use crate::parsers::{DeliveryInfo, EmailParser, OrderInfo};
-
-/// 日本郵便追跡サービスの URL（ゆうパック・ゆうパケット共通）
-const JAPANPOST_TRACKING_URL: &str =
-    "https://trackings.post.japanpost.jp/services/srv/search/input";
+use crate::plugins::JAPANPOST_TRACKING_URL;
 
 /// ふるいちオンライン 発送通知メール用パーサー
 ///
@@ -156,7 +153,7 @@ Tel：09016717298
         let delivery = order.delivery_info.unwrap();
         assert_eq!(
             delivery.carrier_url,
-            Some("https://trackings.post.japanpost.jp/services/srv/search/input".to_string())
+            Some(crate::plugins::JAPANPOST_TRACKING_URL.to_string())
         );
     }
 

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -203,6 +203,18 @@ pub trait VendorPlugin: Send + Sync {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// プラグイン共通定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// 日本郵便追跡サービスの URL - 入力フォーム（ゆうパック・ゆうパケット共通）
+pub(crate) const JAPANPOST_TRACKING_URL: &str =
+    "https://trackings.post.japanpost.jp/services/srv/search/input";
+
+/// 日本郵便追跡サービスの URL - 直接検索（追跡番号をクエリパラメータで渡す形式）
+pub(crate) const JAPANPOST_TRACKING_URL_DIRECT: &str =
+    "https://trackings.post.japanpost.jp/services/srv/search/direct";
+
+// ─────────────────────────────────────────────────────────────────────────────
 // プラグイン共通ヘルパー（pub(crate) で各プラグインから参照）
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/src-tauri/src/plugins/premium_bandai/parsers/mod.rs
+++ b/src-tauri/src/plugins/premium_bandai/parsers/mod.rs
@@ -448,7 +448,8 @@ pub fn carrier_tracking_url(carrier: &str, tracking_number: &str) -> Option<Stri
         || carrier.contains("郵便")
     {
         Some(format!(
-            "https://trackings.post.japanpost.jp/services/srv/search/direct?reqCodeNo1={}",
+            "{}?reqCodeNo1={}",
+            crate::plugins::JAPANPOST_TRACKING_URL_DIRECT,
             tracking_number
         ))
     } else {


### PR DESCRIPTION
## Summary

- `plugins/mod.rs` に `JAPANPOST_TRACKING_URL`（`search/input`）と `JAPANPOST_TRACKING_URL_DIRECT`（`search/direct`）を `pub(crate)` 定数として追加
- `animate/parsers/send.rs` と `furuichi_online/parsers/send.rs` のローカル定数定義を削除し、共通定数を参照するよう変更（テスト内の文字列リテラルも同様）
- `premium_bandai/parsers/mod.rs` の URL リテラル直書きを `JAPANPOST_TRACKING_URL_DIRECT` に差し替え

## Test plan

- [x] `cargo test` で全 867 テスト PASS 確認

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)