### PR TITLE
feat: 駿河屋プラグインを追加・配送業者フィルタをグループ化 (issue #271)

### DIFF
--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -18,6 +18,7 @@ pub mod hobbysearch;
 pub mod kids_dragon;
 pub mod premium_bandai;
 pub mod sagawa;
+pub mod surugaya;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // inventory による自動登録
@@ -444,6 +445,15 @@ mod tests {
             "amiami_cancel",
         ];
         for pt in &amiami_types {
+            assert!(find_plugin(&registry, pt).is_some(), "No plugin for {}", pt);
+        }
+    }
+
+    #[test]
+    fn test_all_surugaya_parser_types_have_plugin() {
+        let registry = build_registry();
+        let surugaya_types = ["surugaya_confirm", "surugaya_send"];
+        for pt in &surugaya_types {
             assert!(find_plugin(&registry, pt).is_some(), "No plugin for {}", pt);
         }
     }

--- a/src-tauri/src/plugins/surugaya/mod.rs
+++ b/src-tauri/src/plugins/surugaya/mod.rs
@@ -1,0 +1,168 @@
+//! 駿河屋プラグイン
+//!
+//! 駿河屋の注文確認メール・発送案内メールのパース対応。
+//! 文字コードは ISO-2022-JP だが、Gmail API 同期時に UTF-8 にデコード済みであることを前提とする。
+//!
+//! | parser_type       | 送信元               | 種別       |
+//! |-------------------|----------------------|------------|
+//! | surugaya_confirm  | order@suruga-ya.jp   | 注文確認   |
+//! | surugaya_send     | order@suruga-ya.jp   | 発送案内   |
+
+pub mod parsers;
+
+use async_trait::async_trait;
+
+use crate::parsers::EmailParser;
+use crate::repository::SqliteOrderRepository;
+
+use super::{
+    apply_internal_date, derive_shop_domain, DefaultShopSetting, DispatchError, DispatchOutcome,
+    PluginRegistration, VendorPlugin,
+};
+
+pub struct SurugayaPlugin;
+
+#[async_trait]
+impl VendorPlugin for SurugayaPlugin {
+    fn parser_types(&self) -> &[&str] {
+        &["surugaya_confirm", "surugaya_send"]
+    }
+
+    fn priority(&self) -> i32 {
+        10
+    }
+
+    fn get_parser(&self, parser_type: &str) -> Option<Box<dyn EmailParser>> {
+        match parser_type {
+            "surugaya_confirm" => Some(Box::new(parsers::confirm::SurugayaConfirmParser)),
+            "surugaya_send" => Some(Box::new(parsers::send::SurugayaSendParser)),
+            _ => None,
+        }
+    }
+
+    fn shop_name(&self) -> &str {
+        "駿河屋"
+    }
+
+    fn default_shop_settings(&self) -> Vec<DefaultShopSetting> {
+        vec![
+            DefaultShopSetting {
+                shop_name: "駿河屋".to_string(),
+                sender_address: "order@suruga-ya.jp".to_string(),
+                parser_type: "surugaya_confirm".to_string(),
+                subject_filters: Some(vec!["ご注文ありがとうございます".to_string()]),
+            },
+            DefaultShopSetting {
+                shop_name: "駿河屋".to_string(),
+                sender_address: "order@suruga-ya.jp".to_string(),
+                parser_type: "surugaya_send".to_string(),
+                subject_filters: Some(vec!["発送のお知らせ".to_string()]),
+            },
+        ]
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch(
+        &self,
+        parser_type: &str,
+        email_id: i64,
+        from_address: Option<&str>,
+        shop_name: &str,
+        internal_date: Option<i64>,
+        body: &str,
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    ) -> Result<DispatchOutcome, DispatchError> {
+        let shop_domain = derive_shop_domain(from_address);
+
+        let mut order_info = {
+            let parser = self.get_parser(parser_type).ok_or_else(|| {
+                DispatchError::ParseFailed(format!("No parser for type: {}", parser_type))
+            })?;
+            parser.parse(body).map_err(DispatchError::ParseFailed)?
+        };
+
+        // 注文確認メールは注文日が本文に含まれないため internal_date で補完する
+        if parser_type == "surugaya_confirm" {
+            apply_internal_date(&mut order_info, internal_date);
+        }
+
+        log::debug!(
+            "[{}] email_id={} order_number={}",
+            parser_type,
+            email_id,
+            order_info.order_number
+        );
+
+        SqliteOrderRepository::save_order_in_tx(
+            tx,
+            &order_info,
+            Some(email_id),
+            shop_domain,
+            Some(shop_name.to_string()),
+        )
+        .await
+        .map_err(DispatchError::SaveFailed)?;
+
+        Ok(DispatchOutcome::OrderSaved(Box::new(order_info)))
+    }
+}
+
+inventory::submit!(PluginRegistration {
+    factory: || Box::new(SurugayaPlugin),
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_surugaya_plugin_parser_types() {
+        let plugin = SurugayaPlugin;
+        assert!(plugin.parser_types().contains(&"surugaya_confirm"));
+        assert!(plugin.parser_types().contains(&"surugaya_send"));
+    }
+
+    #[test]
+    fn test_surugaya_plugin_get_parser_confirm() {
+        let plugin = SurugayaPlugin;
+        assert!(plugin.get_parser("surugaya_confirm").is_some());
+    }
+
+    #[test]
+    fn test_surugaya_plugin_get_parser_send() {
+        let plugin = SurugayaPlugin;
+        assert!(plugin.get_parser("surugaya_send").is_some());
+    }
+
+    #[test]
+    fn test_surugaya_plugin_get_parser_unknown_returns_none() {
+        let plugin = SurugayaPlugin;
+        assert!(plugin.get_parser("unknown").is_none());
+    }
+
+    #[test]
+    fn test_surugaya_plugin_default_shop_settings() {
+        let settings = SurugayaPlugin.default_shop_settings();
+        assert_eq!(settings.len(), 2);
+
+        let confirm = settings
+            .iter()
+            .find(|s| s.parser_type == "surugaya_confirm")
+            .unwrap();
+        assert_eq!(confirm.sender_address, "order@suruga-ya.jp");
+        assert_eq!(
+            confirm.subject_filters.as_deref(),
+            Some(["ご注文ありがとうございます".to_string()].as_slice())
+        );
+
+        let send = settings
+            .iter()
+            .find(|s| s.parser_type == "surugaya_send")
+            .unwrap();
+        assert_eq!(send.sender_address, "order@suruga-ya.jp");
+        assert_eq!(
+            send.subject_filters.as_deref(),
+            Some(["発送のお知らせ".to_string()].as_slice())
+        );
+    }
+}

--- a/src-tauri/src/plugins/surugaya/parsers/confirm.rs
+++ b/src-tauri/src/plugins/surugaya/parsers/confirm.rs
@@ -1,0 +1,146 @@
+use super::{body_to_lines, extract_items, extract_order_number};
+use crate::parsers::{EmailParser, OrderInfo};
+
+/// 駿河屋 注文確認メール用パーサー
+///
+/// 件名：`ご注文ありがとうございます` を含む
+/// 送信元：`order@suruga-ya.jp`
+///
+/// 取引番号は `取引番号:S2204166697` 形式（`S` + 10桁）。
+/// 注文日は本文に含まれないため、`dispatch()` 側で `apply_internal_date()` を使用する。
+/// 合計・送料は注文確認メールには記載なし。
+pub struct SurugayaConfirmParser;
+
+impl EmailParser for SurugayaConfirmParser {
+    fn parse(&self, email_body: &str) -> Result<OrderInfo, String> {
+        let body_lines = body_to_lines(email_body);
+        let lines: Vec<&str> = body_lines.iter().map(|s| s.as_str()).collect();
+
+        let order_number =
+            extract_order_number(&lines).ok_or_else(|| "Order number not found".to_string())?;
+
+        let items = extract_items(&lines);
+        if items.is_empty() {
+            return Err("No items found".to_string());
+        }
+
+        Ok(OrderInfo {
+            order_number,
+            order_date: None, // internal_date で補完
+            delivery_address: None,
+            delivery_info: None,
+            items,
+            subtotal: None,
+            shipping_fee: None,
+            total_amount: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_confirm() -> &'static str {
+        r#"この度は駿河屋にご注文頂き、誠にありがとうございます。
+
+下記商品のご注文を承りました。
+ご注文内容を確認いたしまして、商品の確保・検品に入らせて頂きます。
+
+
+取引番号:S2204166697
+原田 裕基様  ご注文の商品
+──────────────────────────────────
+1-1 \1,656 中古プラモデル 1/144 HG グレイズアイン 「機動戦士ガンダム 鉄血のオルフェンズ」 (603103980001)
+1-2 \828 中古プラモデル 1/144 HGBC ジャイアントガトリング 「ガンダムビルドファイターズトライ」 (603055964001)
+1-3 \644 中古プラモデル 1/144 HGBC ボールデンアームアームズ 「ガンダムビルドファイターズトライ」 (603102455001)
+1-4 \368 中古プラモデル 1/144 長距離狙撃用オプションアーマー(アルト用/ダークグレー) 「30 MINUTES MISSIONS」 (603100256001)
+1-5 \1,472 中古プラモデル 1/144 HG MBF-P02 ガンダムアストレイ レッドフレーム(フライトユニット装備) 「機動戦士ガンダムSEED DESTINY ASTRAY」 (603098529001)
+1-6 \1,748 中古プラモデル 1/144 HGBC ティルトローターパック 「ガンダムビルドダイバーズ」 (603089459001)
+1-7 \1,104 中古プラモデル 1/144 HGAC GUNPLA EVOLUTION PROJECT OZ-06MS リーオー 「新機動戦記ガンダムW」 (603089200001)
+1-8 \1,288 中古プラモデル 1/144 HG GN-000 オーガンダム(実戦配備型) 「機動戦士ガンダム00」 [5055732] (603101318001)
+──────────────────────────────────
+[支払方法] クレジット
+"#
+    }
+
+    #[test]
+    fn test_parse_confirm_order_number() {
+        let order = SurugayaConfirmParser.parse(sample_confirm()).unwrap();
+        assert_eq!(order.order_number, "S2204166697");
+    }
+
+    #[test]
+    fn test_parse_confirm_no_order_date() {
+        let order = SurugayaConfirmParser.parse(sample_confirm()).unwrap();
+        assert!(order.order_date.is_none());
+    }
+
+    #[test]
+    fn test_parse_confirm_item_count() {
+        let order = SurugayaConfirmParser.parse(sample_confirm()).unwrap();
+        assert_eq!(order.items.len(), 8);
+    }
+
+    #[test]
+    fn test_parse_confirm_first_item_price() {
+        let order = SurugayaConfirmParser.parse(sample_confirm()).unwrap();
+        assert_eq!(order.items[0].unit_price, 1656);
+        assert_eq!(order.items[0].quantity, 1);
+        assert_eq!(order.items[0].subtotal, 1656);
+    }
+
+    #[test]
+    fn test_parse_confirm_first_item_name_strips_code() {
+        let order = SurugayaConfirmParser.parse(sample_confirm()).unwrap();
+        let name = &order.items[0].name;
+        assert!(name.contains("グレイズアイン"));
+        // 末尾の商品コード (603103980001) が除去されていること
+        assert!(!name.contains("603103980001"));
+    }
+
+    #[test]
+    fn test_parse_confirm_item_with_bracket_strips_both() {
+        // item 1-8: `[5055732] (603101318001)` が両方除去されること
+        let order = SurugayaConfirmParser.parse(sample_confirm()).unwrap();
+        let name = &order.items[7].name;
+        assert!(name.contains("オーガンダム"));
+        assert!(!name.contains("5055732"));
+        assert!(!name.contains("603101318001"));
+    }
+
+    #[test]
+    fn test_parse_confirm_item_with_paren_in_name() {
+        // item 1-4: `(アルト用/ダークグレー)` が商品名として保持されること
+        let order = SurugayaConfirmParser.parse(sample_confirm()).unwrap();
+        let name = &order.items[3].name;
+        assert!(name.contains("アルト用/ダークグレー"));
+        assert_eq!(order.items[3].unit_price, 368);
+    }
+
+    #[test]
+    fn test_parse_confirm_no_subtotal() {
+        let order = SurugayaConfirmParser.parse(sample_confirm()).unwrap();
+        assert!(order.subtotal.is_none());
+        assert!(order.shipping_fee.is_none());
+        assert!(order.total_amount.is_none());
+    }
+
+    #[test]
+    fn test_parse_confirm_no_delivery_info() {
+        let order = SurugayaConfirmParser.parse(sample_confirm()).unwrap();
+        assert!(order.delivery_info.is_none());
+    }
+
+    #[test]
+    fn test_parse_confirm_no_order_number_returns_error() {
+        let body = "1-1 \\1,000 商品A (600000000001)";
+        assert!(SurugayaConfirmParser.parse(body).is_err());
+    }
+
+    #[test]
+    fn test_parse_confirm_no_items_returns_error() {
+        let body = "取引番号:S2204166697\n\nお問い合わせはこちら";
+        assert!(SurugayaConfirmParser.parse(body).is_err());
+    }
+}

--- a/src-tauri/src/plugins/surugaya/parsers/mod.rs
+++ b/src-tauri/src/plugins/surugaya/parsers/mod.rs
@@ -1,0 +1,388 @@
+use crate::parsers::OrderItem;
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+pub mod confirm;
+pub mod send;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 正規表現
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// 取引番号: `取引番号:S2204166697` または `取引番号：S2204166697`（confirm / send 共通）
+static ORDER_NUMBER_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"取引番号[：:]\s*(S\d{10})").expect("Invalid ORDER_NUMBER_RE"));
+
+/// confirm 商品行: `1-1 \1,656 商品名 (603103980001)`
+/// 行番号・価格・商品名+末尾コードの3グループを取得する
+static ITEM_LINE_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^(\d+-\d+)\s+\\([\d,]+)\s+(.+)$").expect("Invalid ITEM_LINE_RE"));
+
+/// 商品名末尾のコード除去: `商品名 [5055732] (603103980001)` → `商品名`
+/// `[\w+]` 形式の任意ラベルと `(\d+)` 形式のコードを末尾から除去する
+static TRAILING_CODE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\s*(?:\[[^\]]+\]\s*)?\(\d+\)\s*$").expect("Invalid TRAILING_CODE_RE")
+});
+
+/// send 追跡番号: `お問い合わせ番号　　：764336939516`
+///
+/// 複数口の場合は `お問い合わせ番号1　 ：764337098000` / `お問い合わせ番号2　 ：764337098033` の形式になる。
+/// 末尾の数字を省略可能にして先頭の追跡番号を返す。
+static TRACKING_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"お問い合わせ番号\d*[\s　]*[：:]\s*(\d{12})").expect("Invalid TRACKING_RE")
+});
+
+/// send 配送会社: `お届け方法　　　　　：ゆうパック（日本郵便)`
+static CARRIER_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"お届け方法[\s　]*[：:]\s*(.+)").expect("Invalid CARRIER_RE"));
+
+/// send 出荷日: `出荷日　　　　　　　：2022/04/27`
+static SHIP_DATE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"出荷日[\s　]*[：:]\s*(\d{4}/\d{2}/\d{2})").expect("Invalid SHIP_DATE_RE")
+});
+
+/// send 商品合計: `商品合計　　　　　　：\9,108`
+static SUBTOTAL_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^商品合計[\s　]*[：:]\s*\\([\d,]+)").expect("Invalid SUBTOTAL_RE"));
+
+/// send 送料: `送料　　　　　　　　：\0`
+///
+/// ゆうメールでは `送料・通信販売手数料：\0` の形式になるため、
+/// `送料` と `：` の間は任意の文字を許容する。
+/// 「代引手数料」と区別するため行頭アンカーを使用する。
+static SHIPPING_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^送料[^：:]*[：:]\s*\\([\d,]+)").expect("Invalid SHIPPING_RE"));
+
+/// send 支払合計金額: `支払合計金額　　　　：\9,108`
+static TOTAL_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^支払合計金額[\s　]*[：:]\s*\\([\d,]+)").expect("Invalid TOTAL_RE"));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 共通ヘルパー
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// メール本文をトリム済み行リストに変換する
+pub fn body_to_lines(body: &str) -> Vec<String> {
+    body.lines().map(|l| l.trim().to_string()).collect()
+}
+
+/// `取引番号:S2204166697` 形式の取引番号を抽出する（confirm / send 共通）
+pub fn extract_order_number(lines: &[&str]) -> Option<String> {
+    lines
+        .iter()
+        .find_map(|line| ORDER_NUMBER_RE.captures(line).map(|c| c[1].to_string()))
+}
+
+/// confirm 商品行リストを抽出する
+///
+/// フォーマット:
+/// ```text
+/// 1-1 \1,656 中古プラモデル 1/144 HG グレイズアイン ... (603103980001)
+/// 1-8 \1,288 ... 「機動戦士ガンダム00」 [5055732] (603101318001)
+/// ```
+/// - 価格はバックスラッシュ（JIS 円記号）の直後
+/// - 末尾の `(\d+)` は商品コード → 除去する
+/// - 末尾に `[\w+]` 形式のラベルがある場合も除去する
+/// - 数量は常に 1
+pub fn extract_items(lines: &[&str]) -> Vec<OrderItem> {
+    let mut items = Vec::new();
+
+    for line in lines {
+        let trimmed = line.trim();
+        let Some(caps) = ITEM_LINE_RE.captures(trimmed) else {
+            continue;
+        };
+
+        let unit_price: i64 = caps[2].replace(',', "").parse().unwrap_or(0);
+        if unit_price <= 0 {
+            continue;
+        }
+
+        let raw_name = &caps[3];
+        let name = TRAILING_CODE_RE.replace(raw_name, "").trim().to_string();
+        if name.is_empty() {
+            continue;
+        }
+
+        items.push(OrderItem {
+            name,
+            manufacturer: None,
+            model_number: None,
+            unit_price,
+            quantity: 1,
+            subtotal: unit_price,
+            image_url: None,
+        });
+    }
+
+    items
+}
+
+/// send 追跡番号を抽出する: `お問い合わせ番号　　：764336939516`（12桁）
+pub fn extract_tracking_number(lines: &[&str]) -> Option<String> {
+    lines
+        .iter()
+        .find_map(|line| TRACKING_RE.captures(line).map(|c| c[1].to_string()))
+}
+
+/// send 配送会社を抽出して正規化する: `お届け方法　　　　　：ゆうパック（日本郵便)`
+///
+/// `（日本郵便)` の半角閉じ括弧を全角に正規化する（ゆうパック・ゆうメール 共通）。
+pub fn extract_carrier(lines: &[&str]) -> Option<String> {
+    lines.iter().find_map(|line| {
+        CARRIER_RE.captures(line).map(|c| {
+            // 半角閉じ括弧 `)` を全角 `）` に統一する
+            c[1].trim().replace("（日本郵便)", "（日本郵便）")
+        })
+    })
+}
+
+/// send 出荷日を抽出して DB 保存形式に変換する: `2022/04/27` → `2022-04-27 00:00:00`
+pub fn extract_ship_date(lines: &[&str]) -> Option<String> {
+    lines.iter().find_map(|line| {
+        SHIP_DATE_RE.captures(line).map(|c| {
+            let date_slash = &c[1]; // "2022/04/27"
+            format!("{} 00:00:00", date_slash.replace('/', "-"))
+        })
+    })
+}
+
+/// send 商品合計を抽出する: `商品合計　　　　　　：\9,108`
+pub fn extract_subtotal(lines: &[&str]) -> Option<i64> {
+    lines.iter().find_map(|line| {
+        SUBTOTAL_RE
+            .captures(line.trim())
+            .and_then(|c| c[1].replace(',', "").parse().ok())
+    })
+}
+
+/// send 送料を抽出する: `送料　　　　　　　　：\0`
+pub fn extract_shipping_fee(lines: &[&str]) -> Option<i64> {
+    lines.iter().find_map(|line| {
+        SHIPPING_RE
+            .captures(line.trim())
+            .and_then(|c| c[1].replace(',', "").parse().ok())
+    })
+}
+
+/// send 支払合計金額を抽出する: `支払合計金額　　　　：\9,108`
+pub fn extract_total_amount(lines: &[&str]) -> Option<i64> {
+    lines.iter().find_map(|line| {
+        TOTAL_RE
+            .captures(line.trim())
+            .and_then(|c| c[1].replace(',', "").parse().ok())
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// テスト
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── extract_order_number ───
+
+    #[test]
+    fn test_extract_order_number_confirm_format() {
+        let lines = vec!["取引番号:S2204166697"];
+        assert_eq!(
+            extract_order_number(&lines),
+            Some("S2204166697".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_order_number_send_format() {
+        // send: `（取引番号：S2204166697）`
+        let lines = vec!["原田裕基様 （取引番号：S2204166697）"];
+        assert_eq!(
+            extract_order_number(&lines),
+            Some("S2204166697".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_order_number_not_found() {
+        let lines = vec!["商品名：テスト商品"];
+        assert_eq!(extract_order_number(&lines), None);
+    }
+
+    // ─── extract_items ───
+
+    #[test]
+    fn test_extract_items_basic() {
+        let lines = vec!["1-1 \\1,656 中古プラモデル 1/144 HG グレイズアイン (603103980001)"];
+        let items = extract_items(&lines);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].unit_price, 1656);
+        assert_eq!(items[0].quantity, 1);
+        assert_eq!(items[0].subtotal, 1656);
+        assert_eq!(items[0].name, "中古プラモデル 1/144 HG グレイズアイン");
+    }
+
+    #[test]
+    fn test_extract_items_with_bracket_label() {
+        // `[5055732]` が商品名末尾に含まれるケース (item 1-8)
+        let lines = vec!["1-8 \\1,288 中古プラモデル オーガンダム [5055732] (603101318001)"];
+        let items = extract_items(&lines);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].name, "中古プラモデル オーガンダム");
+        assert_eq!(items[0].unit_price, 1288);
+    }
+
+    #[test]
+    fn test_extract_items_with_paren_in_name() {
+        // 商品名内に括弧が含まれるケース: `オーガンダム(実戦配備型)`
+        let lines = vec![
+            "1-4 \\368 長距離狙撃用オプションアーマー(アルト用/ダークグレー) 「30 MINUTES MISSIONS」 (603100256001)",
+        ];
+        let items = extract_items(&lines);
+        assert_eq!(items.len(), 1);
+        assert_eq!(
+            items[0].name,
+            "長距離狙撃用オプションアーマー(アルト用/ダークグレー) 「30 MINUTES MISSIONS」"
+        );
+        assert_eq!(items[0].unit_price, 368);
+    }
+
+    #[test]
+    fn test_extract_items_multiple() {
+        let lines = vec![
+            "1-1 \\1,656 商品A (600000000001)",
+            "1-2 \\828 商品B (600000000002)",
+        ];
+        let items = extract_items(&lines);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].name, "商品A");
+        assert_eq!(items[1].name, "商品B");
+    }
+
+    #[test]
+    fn test_extract_items_non_item_line_ignored() {
+        // セパレーター・ヘッダー行は無視される
+        let lines = vec!["──────────────────────────────────", "取引番号:S2204166697"];
+        assert!(extract_items(&lines).is_empty());
+    }
+
+    // ─── extract_tracking_number ───
+
+    #[test]
+    fn test_extract_tracking_number() {
+        let lines = vec!["お問い合わせ番号　　：764336939516"];
+        assert_eq!(
+            extract_tracking_number(&lines),
+            Some("764336939516".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_tracking_number_multi_parcel() {
+        // 複数口の場合: `お問い合わせ番号1` / `お問い合わせ番号2` 形式
+        let lines = vec![
+            "お問い合わせ番号1　 ：764337098000",
+            "お問い合わせ番号2　 ：764337098033",
+        ];
+        // 先頭の追跡番号を返す
+        assert_eq!(
+            extract_tracking_number(&lines),
+            Some("764337098000".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_tracking_number_not_found() {
+        let lines = vec!["取引番号：S2204166697"];
+        assert_eq!(extract_tracking_number(&lines), None);
+    }
+
+    // ─── extract_carrier ───
+
+    #[test]
+    fn test_extract_carrier_yupack() {
+        // 半角閉じ括弧が含まれる実際のメール形式
+        let lines = vec!["お届け方法　　　　　：ゆうパック（日本郵便)"];
+        assert_eq!(
+            extract_carrier(&lines),
+            Some("ゆうパック（日本郵便）".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_carrier_yumail() {
+        // ゆうメール（追跡番号なし）の配送会社
+        let lines = vec!["お届け方法　　　　　：ゆうメール（日本郵便)"];
+        assert_eq!(
+            extract_carrier(&lines),
+            Some("ゆうメール（日本郵便）".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_carrier_not_found() {
+        let lines = vec!["取引番号：S2204166697"];
+        assert_eq!(extract_carrier(&lines), None);
+    }
+
+    // ─── extract_ship_date ───
+
+    #[test]
+    fn test_extract_ship_date() {
+        let lines = vec!["出荷日　　　　　　　：2022/04/27"];
+        assert_eq!(
+            extract_ship_date(&lines),
+            Some("2022-04-27 00:00:00".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_ship_date_not_found() {
+        let lines = vec!["取引番号：S2204166697"];
+        assert_eq!(extract_ship_date(&lines), None);
+    }
+
+    // ─── extract_subtotal / shipping / total ───
+
+    #[test]
+    fn test_extract_subtotal() {
+        let lines = vec!["商品合計　　　　　　：\\9,108"];
+        assert_eq!(extract_subtotal(&lines), Some(9108));
+    }
+
+    #[test]
+    fn test_extract_shipping_fee_zero() {
+        let lines = vec!["送料　　　　　　　　：\\0"];
+        assert_eq!(extract_shipping_fee(&lines), Some(0));
+    }
+
+    #[test]
+    fn test_extract_shipping_fee_yumail_format() {
+        // ゆうメール形式: `送料・通信販売手数料：\0`
+        let lines = vec!["送料・通信販売手数料：\\0"];
+        assert_eq!(extract_shipping_fee(&lines), Some(0));
+    }
+
+    #[test]
+    fn test_extract_shipping_fee_ignores_codash() {
+        // 「代引手数料」は「送料」とマッチしないこと
+        let lines = vec!["代引手数料　　　　　：\\0"];
+        assert_eq!(extract_shipping_fee(&lines), None);
+    }
+
+    #[test]
+    fn test_extract_total_amount() {
+        let lines = vec!["支払合計金額　　　　：\\9,108"];
+        assert_eq!(extract_total_amount(&lines), Some(9108));
+    }
+
+    // ─── body_to_lines ───
+
+    #[test]
+    fn test_body_to_lines_trims() {
+        let body = "  取引番号:S2204166697  \n  出荷日：2022/04/27  \n";
+        let lines = body_to_lines(body);
+        assert_eq!(lines[0], "取引番号:S2204166697");
+        assert_eq!(lines[1], "出荷日：2022/04/27");
+    }
+}

--- a/src-tauri/src/plugins/surugaya/parsers/send.rs
+++ b/src-tauri/src/plugins/surugaya/parsers/send.rs
@@ -1,0 +1,277 @@
+use super::{
+    body_to_lines, extract_carrier, extract_order_number, extract_ship_date, extract_shipping_fee,
+    extract_subtotal, extract_total_amount, extract_tracking_number,
+};
+use crate::parsers::{DeliveryInfo, EmailParser, OrderInfo};
+use crate::plugins::JAPANPOST_TRACKING_URL;
+
+/// 駿河屋 発送案内メール用パーサー
+///
+/// 件名：`発送のお知らせ` を含む
+/// 送信元：`order@suruga-ya.jp`
+///
+/// 取引番号は `（取引番号：S2204166697）` 形式。
+/// 商品一覧は発送メールに含まれないため `items` は空（confirm で登録済みの商品とマージ済み）。
+/// 金額情報（商品合計・送料・支払合計金額）は本文から抽出する。
+///
+/// # 追跡番号について
+/// ゆうパック等は `お問い合わせ番号：764336939516` として12桁の番号が記載される。
+/// ゆうメール等の追跡不可配送は追跡番号フィールドが存在しない。
+/// この場合、発送通知メールの受信をもって配達完了とみなし、`delivery_status = "delivered"` を設定する。
+pub struct SurugayaSendParser;
+
+impl EmailParser for SurugayaSendParser {
+    fn parse(&self, email_body: &str) -> Result<OrderInfo, String> {
+        let body_lines = body_to_lines(email_body);
+        let lines: Vec<&str> = body_lines.iter().map(|s| s.as_str()).collect();
+
+        let order_number =
+            extract_order_number(&lines).ok_or_else(|| "Order number not found".to_string())?;
+
+        let tracking_number = extract_tracking_number(&lines);
+        let carrier = extract_carrier(&lines);
+
+        let delivery_date = extract_ship_date(&lines);
+        let subtotal = extract_subtotal(&lines);
+        let shipping_fee = extract_shipping_fee(&lines);
+        let total_amount = extract_total_amount(&lines);
+
+        // 追跡番号の有無で delivery_info の構築を切り替える
+        let delivery_info = match tracking_number {
+            Some(tracking) => {
+                // ゆうパック等: 追跡番号あり → "shipped" (デフォルト) で登録、以降追跡で更新
+                carrier.map(|c| DeliveryInfo {
+                    carrier: c,
+                    tracking_number: tracking,
+                    delivery_date,
+                    delivery_time: None,
+                    carrier_url: Some(JAPANPOST_TRACKING_URL.to_string()),
+                    delivery_status: None,
+                })
+            }
+            None => {
+                // ゆうメール等: 追跡不可 → 発送通知受信時点で配達完了とみなす
+                carrier.map(|c| DeliveryInfo {
+                    carrier: c,
+                    tracking_number: String::new(),
+                    delivery_date,
+                    delivery_time: None,
+                    carrier_url: None,
+                    delivery_status: Some("delivered".to_string()),
+                })
+            }
+        };
+
+        Ok(OrderInfo {
+            order_number,
+            order_date: None,
+            delivery_address: None,
+            delivery_info,
+            items: vec![],
+            subtotal,
+            shipping_fee,
+            total_amount,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_send() -> &'static str {
+        r#"原田裕基様 （取引番号：S2204166697）
+
+「駿河屋」にてお買い上げいただき、誠にありがとうございます。
+
+宅配業者、お問い合わせ番号、出荷日は以下のようになります。
+
+商品合計　　　　　　：\9,108
+代引手数料　　　　　：\0
+送料　　　　　　　　：\0
+支払合計金額　　　　：\9,108
+
+お届け方法　　　　　：ゆうパック（日本郵便)
+お問い合わせ番号　　：764336939516
+到着予定日　　　　　：指定なし
+配達時間　　　　　　：指定なし
+出荷日　　　　　　　：2022/04/27
+
+郵便追跡サービス
+http://tracking.post.japanpost.jp/services/srv/search/
+"#
+    }
+
+    fn sample_send_yumail() -> &'static str {
+        // ゆうメール: 追跡番号なし（email 1090 相当）
+        r#"原田裕基様 （取引番号：S2501067868）
+
+「駿河屋」にてお買い上げいただき、誠にありがとうございます。
+
+宅配業者、出荷日は以下のようになります。
+
+商品合計　　　　　　：\5,100
+代引手数料　　　　　：\0
+送料・通信販売手数料：\0
+支払合計金額　　　　：\5,100
+
+お届け方法　　　　　：ゆうメール（日本郵便)
+到着予定日　　　　　：指定なし
+配達時間　　　　　　： -
+出荷日　　　　　　　：2025/01/09
+"#
+    }
+
+    // ─── ゆうパック（追跡あり）───
+
+    #[test]
+    fn test_parse_send_order_number() {
+        let order = SurugayaSendParser.parse(sample_send()).unwrap();
+        assert_eq!(order.order_number, "S2204166697");
+    }
+
+    #[test]
+    fn test_parse_send_tracking_number() {
+        let order = SurugayaSendParser.parse(sample_send()).unwrap();
+        assert_eq!(
+            order.delivery_info.as_ref().unwrap().tracking_number,
+            "764336939516"
+        );
+    }
+
+    #[test]
+    fn test_parse_send_carrier() {
+        let order = SurugayaSendParser.parse(sample_send()).unwrap();
+        assert_eq!(
+            order.delivery_info.as_ref().unwrap().carrier,
+            "ゆうパック（日本郵便）"
+        );
+    }
+
+    #[test]
+    fn test_parse_send_carrier_url() {
+        let order = SurugayaSendParser.parse(sample_send()).unwrap();
+        let url = order.delivery_info.as_ref().unwrap().carrier_url.as_deref();
+        assert_eq!(url, Some(JAPANPOST_TRACKING_URL));
+    }
+
+    #[test]
+    fn test_parse_send_delivery_date() {
+        let order = SurugayaSendParser.parse(sample_send()).unwrap();
+        assert_eq!(
+            order
+                .delivery_info
+                .as_ref()
+                .unwrap()
+                .delivery_date
+                .as_deref(),
+            Some("2022-04-27 00:00:00")
+        );
+    }
+
+    #[test]
+    fn test_parse_send_subtotal() {
+        let order = SurugayaSendParser.parse(sample_send()).unwrap();
+        assert_eq!(order.subtotal, Some(9108));
+    }
+
+    #[test]
+    fn test_parse_send_shipping_fee_zero() {
+        let order = SurugayaSendParser.parse(sample_send()).unwrap();
+        assert_eq!(order.shipping_fee, Some(0));
+    }
+
+    #[test]
+    fn test_parse_send_total_amount() {
+        let order = SurugayaSendParser.parse(sample_send()).unwrap();
+        assert_eq!(order.total_amount, Some(9108));
+    }
+
+    #[test]
+    fn test_parse_send_items_empty() {
+        // 発送メールには商品リストなし
+        let order = SurugayaSendParser.parse(sample_send()).unwrap();
+        assert!(order.items.is_empty());
+    }
+
+    // ─── ゆうメール（追跡なし）───
+
+    #[test]
+    fn test_parse_send_yumail_order_number() {
+        let order = SurugayaSendParser.parse(sample_send_yumail()).unwrap();
+        assert_eq!(order.order_number, "S2501067868");
+    }
+
+    #[test]
+    fn test_parse_send_yumail_delivery_status_delivered() {
+        // 追跡番号なし → 発送通知受信時点で配達完了とみなす
+        let order = SurugayaSendParser.parse(sample_send_yumail()).unwrap();
+        let di = order.delivery_info.as_ref().unwrap();
+        assert_eq!(di.delivery_status.as_deref(), Some("delivered"));
+    }
+
+    #[test]
+    fn test_parse_send_yumail_carrier() {
+        let order = SurugayaSendParser.parse(sample_send_yumail()).unwrap();
+        let di = order.delivery_info.as_ref().unwrap();
+        assert_eq!(di.carrier, "ゆうメール（日本郵便）");
+    }
+
+    #[test]
+    fn test_parse_send_yumail_tracking_number_empty() {
+        // 追跡番号なしは空文字列で登録される
+        let order = SurugayaSendParser.parse(sample_send_yumail()).unwrap();
+        let di = order.delivery_info.as_ref().unwrap();
+        assert!(di.tracking_number.is_empty());
+    }
+
+    #[test]
+    fn test_parse_send_yumail_no_carrier_url() {
+        // 追跡URLは存在しない
+        let order = SurugayaSendParser.parse(sample_send_yumail()).unwrap();
+        let di = order.delivery_info.as_ref().unwrap();
+        assert!(di.carrier_url.is_none());
+    }
+
+    #[test]
+    fn test_parse_send_yumail_amounts() {
+        let order = SurugayaSendParser.parse(sample_send_yumail()).unwrap();
+        assert_eq!(order.subtotal, Some(5100));
+        assert_eq!(order.shipping_fee, Some(0));
+        assert_eq!(order.total_amount, Some(5100));
+    }
+
+    #[test]
+    fn test_parse_send_yumail_delivery_date() {
+        let order = SurugayaSendParser.parse(sample_send_yumail()).unwrap();
+        let di = order.delivery_info.as_ref().unwrap();
+        assert_eq!(di.delivery_date.as_deref(), Some("2025-01-09 00:00:00"));
+    }
+
+    // ─── エラーケース ───
+
+    #[test]
+    fn test_parse_send_no_order_number_returns_error() {
+        let body =
+            "お問い合わせ番号　　：764336939516\nお届け方法　　　　　：ゆうパック（日本郵便)";
+        assert!(SurugayaSendParser.parse(body).is_err());
+    }
+
+    #[test]
+    fn test_parse_send_no_tracking_delivery_info_delivered() {
+        // 追跡番号なし・配送会社あり → delivered で delivery_info が生成される
+        let body = "（取引番号：S2204166697）\nお届け方法　　　　　：ゆうメール（日本郵便)";
+        let order = SurugayaSendParser.parse(body).unwrap();
+        let di = order.delivery_info.as_ref().unwrap();
+        assert_eq!(di.delivery_status.as_deref(), Some("delivered"));
+        assert!(di.tracking_number.is_empty());
+    }
+
+    #[test]
+    fn test_parse_send_no_carrier_no_delivery_info() {
+        // 配送会社なし（追跡あり）は delivery_info が None
+        let body = "（取引番号：S2204166697）\nお問い合わせ番号　　：764336939516";
+        let order = SurugayaSendParser.parse(body).unwrap();
+        assert!(order.delivery_info.is_none());
+    }
+}

--- a/src/components/screens/delivery.tsx
+++ b/src/components/screens/delivery.tsx
@@ -100,6 +100,29 @@ const DELIVERY_STATUS_LABELS: Record<
 
 const ALL_FILTER = 'all';
 
+/** 配送業者グループ定義。新しい配送会社を追加する場合はここにエントリを追加する */
+const CARRIER_GROUPS: {
+  label: string;
+  matches: (carrier: string) => boolean;
+}[] = [
+  {
+    label: '日本郵便',
+    matches: (c) =>
+      c.includes('日本郵便') ||
+      c.includes('ゆうパック') ||
+      c.includes('ゆうパケット') ||
+      c.includes('ゆうメール'),
+  },
+  {
+    label: 'ヤマト運輸',
+    matches: (c) => c.includes('ヤマト') || c.includes('クロネコ'),
+  },
+];
+
+/** carrier がいずれかのグループに属するか調べる */
+const findCarrierGroup = (carrier: string) =>
+  CARRIER_GROUPS.find((g) => g.matches(carrier));
+
 // ---------------------------------------------------------------------------
 // DB query
 // ---------------------------------------------------------------------------
@@ -219,9 +242,17 @@ export function Delivery() {
 
   // --- Derived values ---
 
+  const allUniqueCarriers = Array.from(
+    new Set(rows.map((r) => r.carrier ?? '不明'))
+  );
   const carriers = [
     ALL_FILTER,
-    ...Array.from(new Set(rows.map((r) => r.carrier ?? '不明'))),
+    // データに存在するグループのみラベルを表示する
+    ...CARRIER_GROUPS.filter((g) => allUniqueCarriers.some(g.matches)).map(
+      (g) => g.label
+    ),
+    // どのグループにも属さない配送業者はそのまま表示する
+    ...allUniqueCarriers.filter((c) => !findCarrierGroup(c)),
   ];
   const statuses = [
     ALL_FILTER,
@@ -229,8 +260,17 @@ export function Delivery() {
   ];
 
   const filtered = rows.filter((r) => {
-    if (carrierFilter !== ALL_FILTER && (r.carrier ?? '不明') !== carrierFilter)
-      return false;
+    if (carrierFilter !== ALL_FILTER) {
+      const carrier = r.carrier ?? '不明';
+      const selectedGroup = CARRIER_GROUPS.find(
+        (g) => g.label === carrierFilter
+      );
+      if (selectedGroup) {
+        if (!selectedGroup.matches(carrier)) return false;
+      } else {
+        if (carrier !== carrierFilter) return false;
+      }
+    }
     if (statusFilter !== ALL_FILTER && r.deliveryStatus !== statusFilter)
       return false;
     return true;


### PR DESCRIPTION
## 概要

駿河屋（suruga-ya.jp）のメールパース対応と、配送状況画面の業者フィルタ改善を行いました。

## 変更内容

### Rust: 駿河屋プラグイン追加 (`src-tauri/src/plugins/surugaya/`)

- **`surugaya_confirm`**: 注文確認メール（件名: `ご注文ありがとうございます`）のパーサー
  - 取引番号・商品リストを抽出
  - 注文日は `apply_internal_date()` で補完
- **`surugaya_send`**: 発送案内メール（件名: `発送のお知らせ`）のパーサー
  - 追跡番号あり（ゆうパック等）→ `delivery_status = "shipped"` で登録し以降追跡で更新
  - 追跡番号なし（ゆうメール等）→ 発送通知受信時点で `delivery_status = "delivered"` とみなす
  - 複数口配送の追跡番号（`お問い合わせ番号1`/`お問い合わせ番号2` 形式）に対応
  - 送料フィールドのバリエーション（`送料・通信販売手数料`）に対応

### TypeScript: 配送業者フィルタをグループ化 (`delivery.tsx`)

- `CARRIER_GROUPS` テーブルで業者をグループ化
  - 日本郵便系（ゆうパック・ゆうメール・ゆうパケット等）→「日本郵便」ボタンに集約
  - ヤマト運輸系（ヤマト・クロネコ等）→「ヤマト運輸」ボタンに集約
  - どのグループにも属さない業者はそのまま表示

## テスト

- Rust ユニットテスト 58件 パス
- TypeScript コンパイルエラーなし

Closes #271