### PR TITLE
feat(news): ニュース自動更新機能と最終更新時刻の表示を追加

### DIFF
--- a/src/components/screens/news.tsx
+++ b/src/components/screens/news.tsx
@@ -23,6 +23,7 @@ export function News() {
     items,
     loading: feedLoading,
     error: feedError,
+    lastUpdatedAt,
     refresh: refreshFeed,
   } = useNews(allNewsSources);
   const {
@@ -95,6 +96,15 @@ export function News() {
   return (
     <div className="container mx-auto h-full flex flex-col px-6">
       <PageHeader title="ニュース" description={description} icon={Newspaper}>
+        {lastUpdatedAt && (
+          <span className="text-xs text-muted-foreground">
+            最終更新:{' '}
+            {lastUpdatedAt.toLocaleTimeString('ja-JP', {
+              hour: '2-digit',
+              minute: '2-digit',
+            })}
+          </span>
+        )}
         <Button
           variant="outline"
           size="sm"

--- a/src/hooks/useNews.ts
+++ b/src/hooks/useNews.ts
@@ -7,6 +7,7 @@ interface UseNewsResult {
   items: NewsItem[];
   loading: boolean;
   error: string | null;
+  lastUpdatedAt: Date | null;
   refresh: () => void;
 }
 
@@ -14,6 +15,7 @@ export function useNews(sources: NewsSource[] = allNewsSources): UseNewsResult {
   const [items, setItems] = useState<NewsItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -21,6 +23,7 @@ export function useNews(sources: NewsSource[] = allNewsSources): UseNewsResult {
     try {
       const data = await fetchNewsFromSources(sources);
       setItems(data);
+      setLastUpdatedAt(new Date());
     } catch (e) {
       setError(e instanceof Error ? e.message : 'ニュースの取得に失敗しました');
     } finally {
@@ -30,7 +33,10 @@ export function useNews(sources: NewsSource[] = allNewsSources): UseNewsResult {
 
   useEffect(() => {
     refresh();
+
+    const interval = setInterval(refresh, 10 * 60 * 1000);
+    return () => clearInterval(interval);
   }, [refresh]);
 
-  return { items, loading, error, refresh };
+  return { items, loading, error, lastUpdatedAt, refresh };
 }


### PR DESCRIPTION
## Summary

- `useNews` フックに10分間隔の自動更新（`setInterval`）を追加し、コンポーネントのアンマウント時にクリーンアップ
- ニュース取得成功時に `lastUpdatedAt` を記録
- ニュース画面ヘッダーの更新ボタン左横に「最終更新: HH:MM」を表示（初回取得完了前は非表示）

## Test plan

- [ ] ニュース画面を開き、記事読み込み完了後にヘッダー右側に「最終更新: XX:XX」が表示されることを確認
- [ ] 手動で「更新」ボタンを押すと時刻が更新されることを確認
- [ ] 10分待機後、自動的に再取得・時刻更新されることを確認
- [ ] 別画面に移動してニュース画面に戻ってもタイマーが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)