### PR TITLE
feat: 駿河屋マイページHTMLフェッチとパースの分離

### DIFF
--- a/src-tauri/src/commands/amazon_session.rs
+++ b/src-tauri/src/commands/amazon_session.rs
@@ -20,7 +20,6 @@ use std::time::Duration;
 use sqlx::SqlitePool;
 use tauri::{AppHandle, Emitter, Listener, Manager, WebviewUrl, WebviewWindowBuilder};
 
-
 // ─────────────────────────────────────────────────────────────────────────────
 // 状態管理
 // ─────────────────────────────────────────────────────────────────────────────
@@ -138,8 +137,7 @@ pub async fn start_amazon_order_fetch(
 
     tokio::spawn(async move {
         let result =
-            run_order_fetch_batch(&app_clone, &pool_clone, &win, &state_clone, force_refetch)
-                .await;
+            run_order_fetch_batch(&app_clone, &pool_clone, &win, &state_clone, force_refetch).await;
         state_clone.finish();
 
         #[derive(serde::Serialize, Clone)]
@@ -313,7 +311,6 @@ fn is_order_detail_url(url: &str) -> bool {
     (url.contains("your-orders/order-details") || url.contains("gp/your-account/order-details"))
         && url.contains("orderID")
 }
-
 
 // ─────────────────────────────────────────────────────────────────────────────
 // テスト

--- a/src-tauri/src/commands/surugaya_session.rs
+++ b/src-tauri/src/commands/surugaya_session.rs
@@ -20,7 +20,6 @@ use std::time::Duration;
 use sqlx::SqlitePool;
 use tauri::{AppHandle, Emitter, Listener, Manager, WebviewUrl, WebviewWindowBuilder};
 
-
 // ─────────────────────────────────────────────────────────────────────────────
 // 状態管理
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src-tauri/src/commands/surugaya_session.rs
+++ b/src-tauri/src/commands/surugaya_session.rs
@@ -20,7 +20,6 @@ use std::time::Duration;
 use sqlx::SqlitePool;
 use tauri::{AppHandle, Emitter, Listener, Manager, WebviewUrl, WebviewWindowBuilder};
 
-use crate::{plugins::surugaya_mp::html_parser, repository::SqliteOrderRepository};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 状態管理
@@ -121,13 +120,13 @@ pub async fn open_surugaya_login_window(app_handle: AppHandle) -> Result<(), Str
 /// 駿河屋マイページ取得バッチを開始
 ///
 /// `surugaya-session` ウィンドウが開いていない（未ログイン）場合はエラーを返す。
-/// 取得対象は `htmls` テーブルの駿河屋マイページ URL の全レコード。
-/// パーサーは都度更新されるため、メールパースと同様に毎回全量を再パースする。
+/// `force_refetch = true` の場合は取得済み HTML も含めて全件再取得する。
 #[tauri::command]
 pub async fn start_surugaya_mypage_fetch(
     app_handle: AppHandle,
     pool: tauri::State<'_, SqlitePool>,
     session_state: tauri::State<'_, SurugayaSessionState>,
+    force_refetch: Option<bool>,
 ) -> Result<(), String> {
     let win = app_handle
         .get_webview_window("surugaya-session")
@@ -138,9 +137,11 @@ pub async fn start_surugaya_mypage_fetch(
     let pool_clone = pool.inner().clone();
     let app_clone = app_handle.clone();
     let state_clone = session_state.inner().clone();
+    let force_refetch = force_refetch.unwrap_or(false);
 
     tokio::spawn(async move {
-        let result = run_mypage_batch(&app_clone, &pool_clone, &win, &state_clone).await;
+        let result =
+            run_mypage_batch(&app_clone, &pool_clone, &win, &state_clone, force_refetch).await;
         state_clone.finish();
 
         #[derive(serde::Serialize, Clone)]
@@ -203,19 +204,32 @@ pub(crate) async fn run_mypage_batch(
     pool: &SqlitePool,
     win: &tauri::WebviewWindow,
     state: &SurugayaSessionState,
+    force_refetch: bool,
 ) -> Result<bool, String> {
-    // パーサーは都度更新されるため、全量を再パース対象とする（メールパースと同方針）
-    let targets: Vec<(i64, String)> = sqlx::query_as(
+    // force_refetch = true: 取得済みを含む全件を対象とする（HTML 更新時に使用）
+    // force_refetch = false: html_content IS NULL のみ（差分取得・デフォルト）
+    let sql = if force_refetch {
         "SELECT id, url FROM htmls \
          WHERE url LIKE 'https://www.suruga-ya.jp/pcmypage/%' \
-         ORDER BY id",
-    )
-    .fetch_all(pool)
-    .await
-    .map_err(|e| format!("Failed to fetch target htmls: {e}"))?;
+         ORDER BY id"
+    } else {
+        "SELECT id, url FROM htmls \
+         WHERE html_content IS NULL \
+           AND url LIKE 'https://www.suruga-ya.jp/pcmypage/%' \
+         ORDER BY id"
+    };
+
+    let targets: Vec<(i64, String)> = sqlx::query_as(sql)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| format!("Failed to fetch target htmls: {e}"))?;
 
     let total = targets.len();
-    log::info!("[surugaya_session] {} mypage(s) to fetch", total);
+    log::info!(
+        "[surugaya_session] {} mypage(s) to fetch (force_refetch={})",
+        total,
+        force_refetch
+    );
 
     for (i, (html_id, url)) in targets.into_iter().enumerate() {
         if state.should_cancel() {
@@ -223,7 +237,6 @@ pub(crate) async fn run_mypage_batch(
             return Ok(true);
         }
 
-        // 進捗イベント
         let _ = app.emit(
             "surugaya:fetch_progress",
             serde_json::json!({ "current": i + 1, "total": total, "url": &url }),
@@ -237,66 +250,21 @@ pub(crate) async fn run_mypage_batch(
             }
         };
 
-        // HTML をパース
-        let mypage_info = match html_parser::parse_mypage_html(&html) {
-            Ok(info) => info,
-            Err(e) => {
-                log::warn!("[surugaya_session] Failed to parse {}: {e}", url);
-                continue;
-            }
-        };
-
-        // トランザクションで DB 更新
-        let mut tx = pool
-            .begin()
+        // htmls テーブルに html_content を保存（パースは run_batch_parse_task で行う）
+        if let Err(e) = sqlx::query("UPDATE htmls SET html_content = ? WHERE id = ?")
+            .bind(&html)
+            .bind(html_id)
+            .execute(pool)
             .await
-            .map_err(|e| format!("Failed to begin tx: {e}"))?;
-
-        // 既存注文に items / delivery_info を追加・更新
-        if let Err(e) = SqliteOrderRepository::save_order_in_tx(
-            &mut tx,
-            &mypage_info.order_info,
-            None,
-            Some("suruga-ya.jp".to_string()),
-            None,
-        )
-        .await
         {
-            log::warn!("[surugaya_session] save_order failed for {}: {e}", url);
-            // save_order_in_tx が失敗した場合は、このトランザクション全体をロールバックし、
-            // analysis_status を completed に更新しないようにする
-            if let Err(rollback_err) = tx.rollback().await {
-                log::error!(
-                    "[surugaya_session] Failed to rollback tx after save_order error for {}: {rollback_err}",
-                    url
-                );
-            }
-            // 現在処理中の HTML のみスキップし、次の HTML の処理を続行する
+            log::warn!(
+                "[surugaya_session] Failed to save html_content for {}: {e}",
+                url
+            );
             continue;
         }
 
-        // htmls テーブルを更新（html_content 保存 + analysis_status = completed）
-        if let Err(e) = sqlx::query(
-            "UPDATE htmls SET html_content = ?, analysis_status = 'completed' WHERE id = ?",
-        )
-        .bind(&html)
-        .bind(html_id)
-        .execute(&mut *tx)
-        .await
-        {
-            log::warn!("[surugaya_session] Failed to update htmls {}: {e}", url);
-        }
-
-        tx.commit()
-            .await
-            .map_err(|e| format!("Failed to commit: {e}"))?;
-
-        log::info!(
-            "[surugaya_session] Processed {} ({}/{})",
-            mypage_info.trade_code,
-            i + 1,
-            total
-        );
+        log::info!("[surugaya_session] Fetched HTML ({}/{})", i + 1, total);
     }
 
     Ok(false)

--- a/src-tauri/src/orchestration/parse_orchestrator.rs
+++ b/src-tauri/src/orchestration/parse_orchestrator.rs
@@ -11,8 +11,9 @@ use crate::batch_runner::{BatchProgressEvent, BatchRunner};
 use crate::parsers::EmailRow;
 use crate::parsers::{
     EmailParseContext, EmailParseTask, HtmlParseContext, HtmlParseInput, HtmlParseTask,
-    ShopSettingsCache, EMAIL_PARSE_EVENT_NAME, EMAIL_PARSE_TASK_NAME, HTML_PARSE_EVENT_NAME,
-    HTML_PARSE_TASK_NAME,
+    ShopSettingsCache, SurugayaHtmlParseContext, SurugayaHtmlParseInput, SurugayaHtmlParseTask,
+    EMAIL_PARSE_EVENT_NAME, EMAIL_PARSE_TASK_NAME, HTML_PARSE_EVENT_NAME, HTML_PARSE_TASK_NAME,
+    SURUGAYA_HTML_PARSE_EVENT_NAME, SURUGAYA_HTML_PARSE_TASK_NAME,
 };
 use crate::repository::{
     ParseRepository, ShopSettingsRepository, SqliteParseRepository, SqliteShopSettingsRepository,
@@ -189,13 +190,88 @@ async fn run_batch_parse_task_with<A: BatchCommandsApp>(
         }
     }
 
-    // HTML パース（Amazon 注文詳細）
+    // 駿河屋 HTML パース
     // html_content が保存済みのレコードをすべてパースする。冪等なので何度でも再実行可能。
+    if !parse_state.is_cancelled() {
+        run_surugaya_html_parse_step(app, &pool, &parse_state, batch_size).await;
+    }
+
+    // Amazon 注文詳細 HTML パース
     if !parse_state.is_cancelled() {
         run_html_parse_step(app, &pool, &parse_state, batch_size).await;
     }
 
     parse_state.finish();
+}
+
+/// 駿河屋マイページ HTML のパースステップ
+async fn run_surugaya_html_parse_step<A: BatchCommandsApp>(
+    app: &A,
+    pool: &SqlitePool,
+    parse_state: &crate::parsers::ParseState,
+    batch_size: usize,
+) {
+    let targets: Vec<(i64, String, String)> = match sqlx::query_as(
+        "SELECT id, url, html_content FROM htmls \
+         WHERE html_content IS NOT NULL \
+           AND url LIKE 'https://www.suruga-ya.jp/pcmypage/%' \
+         ORDER BY id",
+    )
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            log::error!("[surugaya_html_parse] Failed to fetch html targets: {e}");
+            return;
+        }
+    };
+
+    if targets.is_empty() {
+        log::info!("[surugaya_html_parse] No stored HTML to parse");
+        let complete_event = BatchProgressEvent::complete(
+            SURUGAYA_HTML_PARSE_TASK_NAME,
+            0,
+            0,
+            0,
+            "パース対象の HTML がありません".to_string(),
+        );
+        app.emit_event(SURUGAYA_HTML_PARSE_EVENT_NAME, complete_event);
+        return;
+    }
+
+    log::info!("[surugaya_html_parse] {} HTML(s) to parse", targets.len());
+
+    let inputs: Vec<SurugayaHtmlParseInput> = targets
+        .into_iter()
+        .map(|(html_id, url, html_content)| SurugayaHtmlParseInput {
+            html_id,
+            url,
+            html_content,
+        })
+        .collect();
+
+    let task = SurugayaHtmlParseTask;
+    let context = SurugayaHtmlParseContext {
+        pool: Arc::new(pool.clone()),
+    };
+    let runner = BatchRunner::new(task, batch_size, 0);
+
+    match runner
+        .run(app, inputs, &context, || parse_state.is_cancelled())
+        .await
+    {
+        Ok(result) => {
+            log::info!(
+                "[surugaya_html_parse] Completed: success={}, failed={}",
+                result.success_count,
+                result.failed_count
+            );
+        }
+        Err(e) => {
+            log::error!("[surugaya_html_parse] BatchRunner failed: {e}");
+        }
+    }
 }
 
 /// Amazon 注文詳細 HTML のパースステップ

--- a/src-tauri/src/orchestration/pipeline_steps.rs
+++ b/src-tauri/src/orchestration/pipeline_steps.rs
@@ -161,8 +161,7 @@ pub(crate) async fn run_surugaya_step(app: &tauri::AppHandle, pool: &SqlitePool)
 
     log::info!("[Pipeline] Surugaya mypage fetch step (diff only)");
     // force_refetch = false: 差分取得のみ（パイプラインは効率優先）
-    let result =
-        surugaya_session::run_mypage_batch(app, pool, &win, &session_state, false).await;
+    let result = surugaya_session::run_mypage_batch(app, pool, &win, &session_state, false).await;
     session_state.finish();
 
     let (cancelled, error) = match result {

--- a/src-tauri/src/orchestration/pipeline_steps.rs
+++ b/src-tauri/src/orchestration/pipeline_steps.rs
@@ -129,9 +129,9 @@ pub(crate) async fn run_parse_step(app: &tauri::AppHandle, pool: &SqlitePool) ->
     }
 }
 
-/// 駿河屋マイページ取得ステップ。
+/// 駿河屋マイページ HTML フェッチステップ（差分取得）。
 /// `surugaya-session` ウィンドウが開いていない場合は Skipped を返す。
-/// 実行件数を返せないため常に `StepOutcome::Unknown` を返す（後続ステップは継続する）。
+/// パース処理は `run_parse_step` 内の `run_surugaya_html_parse_step` で行う。
 #[allow(dead_code)]
 pub(crate) async fn run_surugaya_step(app: &tauri::AppHandle, pool: &SqlitePool) -> StepOutcome {
     use crate::commands::{surugaya_session, SurugayaSessionState};
@@ -159,8 +159,10 @@ pub(crate) async fn run_surugaya_step(app: &tauri::AppHandle, pool: &SqlitePool)
         return StepOutcome::Skipped;
     }
 
-    log::info!("[Pipeline] Surugaya mypage fetch step");
-    let result = surugaya_session::run_mypage_batch(app, pool, &win, &session_state).await;
+    log::info!("[Pipeline] Surugaya mypage fetch step (diff only)");
+    // force_refetch = false: 差分取得のみ（パイプラインは効率優先）
+    let result =
+        surugaya_session::run_mypage_batch(app, pool, &win, &session_state, false).await;
     session_state.finish();
 
     let (cancelled, error) = match result {

--- a/src-tauri/src/orchestration/ui_pipeline.rs
+++ b/src-tauri/src/orchestration/ui_pipeline.rs
@@ -1,7 +1,8 @@
 //! UI 一括パースパイプライン。
 //!
 //! `start_full_parse_pipeline` コマンドから呼ばれ、
-//! ① メールパース → ② 駿河屋HTMLパース → ③ 商品名パース → ④ 配送確認
+//! ① 駿河屋HTMLフェッチ → ② メールパース（駿河屋・Amazon HTML パース含む）
+//! → ③ 商品名パース → ④ 配送確認
 //! をベストエフォート方式で順番に実行する。
 //!
 //! 各ステップの実装は [`super::pipeline_steps`] で共通化されており、
@@ -37,20 +38,20 @@ pub enum PipelineStep {
 pub async fn run_full_parse_pipeline(app: tauri::AppHandle, pool: SqlitePool) {
     log::info!("[UI Pipeline] Starting full parse pipeline");
 
-    // Step 1: メールパース
-    emit_step_started(&app, PipelineStep::Parse);
-    let parse_outcome = run_parse_step(&app, &pool).await;
-    log::info!(
-        "[UI Pipeline] Step 1/4 parse: {}",
-        outcome_label(&parse_outcome)
-    );
-
-    // Step 2: 駿河屋HTMLパース
+    // Step 1: 駿河屋HTMLフェッチ（surugaya-session ウィンドウが開いていない場合はスキップ）
     emit_step_started(&app, PipelineStep::Surugaya);
     let surugaya_outcome = run_surugaya_step(&app, &pool).await;
     log::info!(
-        "[UI Pipeline] Step 2/4 surugaya: {}",
+        "[UI Pipeline] Step 1/4 surugaya_fetch: {}",
         outcome_label(&surugaya_outcome)
+    );
+
+    // Step 2: メールパース（駿河屋・Amazon の保存済み HTML パースも含む）
+    emit_step_started(&app, PipelineStep::Parse);
+    let parse_outcome = run_parse_step(&app, &pool).await;
+    log::info!(
+        "[UI Pipeline] Step 2/4 parse: {}",
+        outcome_label(&parse_outcome)
     );
 
     // Step 3: 商品名パース

--- a/src-tauri/src/orchestration/ui_pipeline.rs
+++ b/src-tauri/src/orchestration/ui_pipeline.rs
@@ -1,10 +1,11 @@
 //! UI 一括パースパイプライン。
 //!
 //! `start_full_parse_pipeline` コマンドから呼ばれ、
-//! ① 駿河屋HTMLフェッチ → ② メールパース（駿河屋・Amazon HTML パース含む）
-//! → ③ 商品名パース → ④ 配送確認
+//! ① メールパース（駿河屋・Amazon の保存済み HTML パース含む）
+//! → ② 商品名パース → ③ 配送確認
 //! をベストエフォート方式で順番に実行する。
 //!
+//! HTML フェッチ（WebView）は別途手動で実行する。
 //! 各ステップの実装は [`super::pipeline_steps`] で共通化されており、
 //! スケジューラ用 [`super::pipeline_orchestrator`] と共有する。
 
@@ -12,7 +13,7 @@ use sqlx::sqlite::SqlitePool;
 use tauri::Emitter;
 
 use super::pipeline_steps::{
-    run_delivery_check_step, run_parse_step, run_product_parse_step, run_surugaya_step, StepOutcome,
+    run_delivery_check_step, run_parse_step, run_product_parse_step, StepOutcome,
 };
 
 /// 各ステップの名前（`full-parse:step_started` イベントのペイロード）
@@ -20,7 +21,6 @@ use super::pipeline_steps::{
 #[serde(rename_all = "snake_case")]
 pub enum PipelineStep {
     Parse,
-    Surugaya,
     ProductParse,
     DeliveryCheck,
 }
@@ -28,41 +28,34 @@ pub enum PipelineStep {
 /// UI 一括パースパイプラインを実行する。`start_full_parse_pipeline` コマンドから呼ばれる。
 ///
 /// ## 実行順序
-/// ① メールパース → ② 駿河屋HTMLパース → ③ 商品名パース → ④ 配送確認
+/// ① メールパース（駿河屋・Amazon の保存済み HTML パース含む）
+/// → ② 商品名パース → ③ 配送確認
 ///
 /// ## 方針
 /// - ベストエフォート：各ステップの成否に関わらず次のステップへ進む
-/// - 駿河屋ステップは `surugaya-session` ウィンドウが開いていない場合はスキップ
+/// - HTML フェッチ（WebView）は含まない。事前に手動で実行しておく
 /// - 各ステップ開始前に `full-parse:step_started` イベントを emit する
 /// - 全ステップ完了後に `full-parse:complete` イベントを emit する
 pub async fn run_full_parse_pipeline(app: tauri::AppHandle, pool: SqlitePool) {
     log::info!("[UI Pipeline] Starting full parse pipeline");
 
-    // Step 1: 駿河屋HTMLフェッチ（surugaya-session ウィンドウが開いていない場合はスキップ）
-    emit_step_started(&app, PipelineStep::Surugaya);
-    let surugaya_outcome = run_surugaya_step(&app, &pool).await;
-    log::info!(
-        "[UI Pipeline] Step 1/4 surugaya_fetch: {}",
-        outcome_label(&surugaya_outcome)
-    );
-
-    // Step 2: メールパース（駿河屋・Amazon の保存済み HTML パースも含む）
+    // Step 1: メールパース（駿河屋・Amazon の保存済み HTML パースも含む）
     emit_step_started(&app, PipelineStep::Parse);
     let parse_outcome = run_parse_step(&app, &pool).await;
     log::info!(
-        "[UI Pipeline] Step 2/4 parse: {}",
+        "[UI Pipeline] Step 1/3 parse: {}",
         outcome_label(&parse_outcome)
     );
 
-    // Step 3: 商品名パース
+    // Step 2: 商品名パース
     emit_step_started(&app, PipelineStep::ProductParse);
     run_product_parse_step(&app, &pool).await;
-    log::info!("[UI Pipeline] Step 3/4 product_parse: done");
+    log::info!("[UI Pipeline] Step 2/3 product_parse: done");
 
-    // Step 4: 配送状況確認
+    // Step 3: 配送状況確認
     emit_step_started(&app, PipelineStep::DeliveryCheck);
     run_delivery_check_step(&app, &pool).await;
-    log::info!("[UI Pipeline] Step 4/4 delivery_check: done");
+    log::info!("[UI Pipeline] Step 3/3 delivery_check: done");
 
     // 完了イベント
     let _ = app.emit("full-parse:complete", ());

--- a/src-tauri/src/parsers/html_parse_task.rs
+++ b/src-tauri/src/parsers/html_parse_task.rs
@@ -63,8 +63,7 @@ impl BatchTask for HtmlParseTask {
         let order_number = extract_order_id_from_url(&input.url)
             .ok_or_else(|| format!("Cannot extract orderID from URL: {}", input.url))?;
 
-        let order_info =
-            html_parser::parse_order_detail_html(&input.html_content, &order_number)?;
+        let order_info = html_parser::parse_order_detail_html(&input.html_content, &order_number)?;
 
         let mut tx = ctx
             .pool
@@ -118,8 +117,7 @@ mod tests {
 
     #[test]
     fn test_extract_order_id_standard() {
-        let url =
-            "https://www.amazon.co.jp/your-orders/order-details?orderID=123-4567890-1234567";
+        let url = "https://www.amazon.co.jp/your-orders/order-details?orderID=123-4567890-1234567";
         assert_eq!(
             extract_order_id_from_url(url),
             Some("123-4567890-1234567".to_string())

--- a/src-tauri/src/parsers/mod.rs
+++ b/src-tauri/src/parsers/mod.rs
@@ -46,6 +46,12 @@ pub use html_parse_task::{
     HTML_PARSE_TASK_NAME,
 };
 
+pub mod surugaya_html_parse_task;
+pub use surugaya_html_parse_task::{
+    SurugayaHtmlParseContext, SurugayaHtmlParseInput, SurugayaHtmlParseOutput,
+    SurugayaHtmlParseTask, SURUGAYA_HTML_PARSE_EVENT_NAME, SURUGAYA_HTML_PARSE_TASK_NAME,
+};
+
 /// パース状態管理（`BatchRunState` の薄いラッパー）
 ///
 /// 進捗テーブル削除後はメモリのみで状態を管理する。

--- a/src-tauri/src/parsers/surugaya_html_parse_task.rs
+++ b/src-tauri/src/parsers/surugaya_html_parse_task.rs
@@ -1,0 +1,89 @@
+//! 駿河屋マーケットプレイス マイページ HTML パースタスク
+//!
+//! `htmls` テーブルに保存済みの HTML を読み込み、注文情報をパースして DB に保存する。
+//! WebView（ログイン）不要で何度でも再実行できる。
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use sqlx::SqlitePool;
+
+use crate::batch_runner::BatchTask;
+use crate::plugins::surugaya_mp::html_parser;
+use crate::repository::SqliteOrderRepository;
+
+pub const SURUGAYA_HTML_PARSE_TASK_NAME: &str = "駿河屋HTMLパース";
+pub const SURUGAYA_HTML_PARSE_EVENT_NAME: &str = "batch-progress";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 入出力・コンテキスト型
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct SurugayaHtmlParseInput {
+    pub html_id: i64,
+    pub url: String,
+    pub html_content: String,
+}
+
+pub struct SurugayaHtmlParseOutput {
+    pub html_id: i64,
+    pub trade_code: String,
+}
+
+pub struct SurugayaHtmlParseContext {
+    pub pool: Arc<SqlitePool>,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BatchTask 実装
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub struct SurugayaHtmlParseTask;
+
+#[async_trait]
+impl BatchTask for SurugayaHtmlParseTask {
+    type Input = SurugayaHtmlParseInput;
+    type Output = SurugayaHtmlParseOutput;
+    type Context = SurugayaHtmlParseContext;
+
+    fn name(&self) -> &str {
+        SURUGAYA_HTML_PARSE_TASK_NAME
+    }
+
+    fn event_name(&self) -> &str {
+        SURUGAYA_HTML_PARSE_EVENT_NAME
+    }
+
+    async fn process(
+        &self,
+        input: Self::Input,
+        ctx: &Self::Context,
+    ) -> Result<Self::Output, String> {
+        let mypage_info = html_parser::parse_mypage_html(&input.html_content)?;
+
+        let mut tx = ctx
+            .pool
+            .begin()
+            .await
+            .map_err(|e| format!("Failed to begin tx: {e}"))?;
+
+        SqliteOrderRepository::save_order_in_tx(
+            &mut tx,
+            &mypage_info.order_info,
+            None,
+            Some("suruga-ya.jp".to_string()),
+            None,
+        )
+        .await?;
+
+        tx.commit()
+            .await
+            .map_err(|e| format!("Failed to commit: {e}"))?;
+
+        Ok(SurugayaHtmlParseOutput {
+            html_id: input.html_id,
+            trade_code: mypage_info.trade_code,
+        })
+    }
+}

--- a/src/components/screens/batch.tsx
+++ b/src/components/screens/batch.tsx
@@ -30,6 +30,7 @@ export function Batch() {
     progress: surugayaProgress,
     openLoginWindow,
     startFetch,
+    startRefetchAll: startSurugayaRefetchAll,
     cancelFetch,
   } = useSurugayaSession();
   const {
@@ -177,6 +178,16 @@ export function Batch() {
     }
   };
 
+  const handleStartSurugayaRefetchAll = async () => {
+    try {
+      await startSurugayaRefetchAll();
+    } catch (err) {
+      toastError(
+        `駿河屋マイページ全件再取得の開始に失敗しました: ${formatError(err)}`
+      );
+    }
+  };
+
   // --- Amazon order fetch handlers ---
   const handleOpenAmazonLogin = async () => {
     try {
@@ -228,8 +239,8 @@ export function Batch() {
         </CardHeader>
         <CardContent className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            メールパース → 駿河屋HTMLパース → 商品名解析 → 配送状況確認
-            をまとめて順番に実行します。
+            駿河屋HTMLフェッチ → メールパース（駿河屋・Amazon HTML パース含む）
+            → 商品名解析 → 配送状況確認 をまとめて順番に実行します。
             各ステップの成否に関わらず次のステップへ進みます。
           </p>
           {isPipelineRunning && pipelineCurrentStep && (
@@ -418,7 +429,7 @@ export function Batch() {
       <BatchSection
         title="5. 駿河屋マイページHTML取得"
         controlTitle="マイページ取得コントロール"
-        controlDescription="駿河屋マイページにアクセスして注文HTMLを取得します"
+        controlDescription="駿河屋マイページにアクセスして注文HTMLを取得・保存します（パースは「メールパース」で実行）"
         isRunning={isFetching}
         progress={surugayaProgress}
         onStart={handleStartSurugayaFetch}
@@ -446,8 +457,27 @@ export function Batch() {
             >
               ログインウィンドウを開く
             </Button>
+            <Button
+              onClick={handleStartSurugayaRefetchAll}
+              disabled={
+                isPipelineRunning ||
+                isSyncing ||
+                isParsing ||
+                isProductNameParsing ||
+                isChecking ||
+                isFetching ||
+                isAmazonFetching
+              }
+              variant="outline"
+              size="sm"
+            >
+              全件再取得
+            </Button>
             <p className="text-xs text-muted-foreground">
               まずログインウィンドウを開いて駿河屋にログインしてから、取得開始を押してください。
+              取得済みのページは再アクセスしません。パースは「2.
+              メールパース」と同じタイミングで自動実行されます。
+              HTMLが更新されている場合は「全件再取得」を使用してください。
             </p>
           </div>
         }
@@ -545,10 +575,14 @@ export function Batch() {
           <ol className="list-decimal list-inside space-y-1 ml-2">
             <li>Gmail同期でメールを取得</li>
             <li>
+              駿河屋マイページHTML取得（駿河屋ご利用時のみ・事前にログイン必要）
+            </li>
+            <li>
               Amazon注文詳細HTML取得（Amazonご利用時のみ・事前にログイン必要）
             </li>
             <li>
-              メールパースで注文情報を抽出（Amazon注文詳細HTMLのパースも同時実行）
+              メールパースで注文情報を抽出（駿河屋・Amazon
+              の保存済みHTMLパースも同時実行）
             </li>
             <li>商品名解析（AI）でメーカー情報を抽出</li>
             <li>配送状況確認で各荷物の現在状況を記録</li>

--- a/src/components/screens/batch.tsx
+++ b/src/components/screens/batch.tsx
@@ -239,9 +239,10 @@ export function Batch() {
         </CardHeader>
         <CardContent className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            駿河屋HTMLフェッチ → メールパース（駿河屋・Amazon HTML パース含む）
-            → 商品名解析 → 配送状況確認 をまとめて順番に実行します。
+            メールパース（駿河屋・Amazon の保存済み HTML パース含む） →
+            商品名解析 → 配送状況確認 をまとめて順番に実行します。
             各ステップの成否に関わらず次のステップへ進みます。
+            HTMLフェッチ（5・6番）は事前に手動で実行してください。
           </p>
           {isPipelineRunning && pipelineCurrentStep && (
             <p className="text-sm font-medium text-primary">

--- a/src/contexts/full-parse-pipeline-context-value.ts
+++ b/src/contexts/full-parse-pipeline-context-value.ts
@@ -9,15 +9,10 @@
 import { createContext } from 'react';
 
 /** バックエンドの `PipelineStep` enum に対応する型 */
-export type PipelineStep =
-  | 'parse'
-  | 'surugaya'
-  | 'product_parse'
-  | 'delivery_check';
+export type PipelineStep = 'parse' | 'product_parse' | 'delivery_check';
 
 /** 各ステップの日本語ラベル */
 export const PIPELINE_STEP_LABELS: Record<PipelineStep, string> = {
-  surugaya: '駿河屋HTMLフェッチ',
   parse: 'メールパース（HTML含む）',
   product_parse: '商品名解析',
   delivery_check: '配送状況確認',

--- a/src/contexts/full-parse-pipeline-context-value.ts
+++ b/src/contexts/full-parse-pipeline-context-value.ts
@@ -17,8 +17,8 @@ export type PipelineStep =
 
 /** 各ステップの日本語ラベル */
 export const PIPELINE_STEP_LABELS: Record<PipelineStep, string> = {
-  parse: 'メールパース',
-  surugaya: '駿河屋HTMLパース',
+  surugaya: '駿河屋HTMLフェッチ',
+  parse: 'メールパース（HTML含む）',
   product_parse: '商品名解析',
   delivery_check: '配送状況確認',
 };

--- a/src/contexts/surugaya-session-context-value.ts
+++ b/src/contexts/surugaya-session-context-value.ts
@@ -5,7 +5,10 @@ export type SurugayaSessionContextType = {
   isFetching: boolean;
   progress: BatchProgress | null;
   openLoginWindow: () => Promise<void>;
+  /** 差分取得（html_content IS NULL のみ） */
   startFetch: () => Promise<void>;
+  /** 全件再取得（取得済みを含む全 URL を再フェッチ） */
+  startRefetchAll: () => Promise<void>;
   cancelFetch: () => Promise<void>;
 };
 

--- a/src/contexts/surugaya-session-provider.tsx
+++ b/src/contexts/surugaya-session-provider.tsx
@@ -100,7 +100,18 @@ export function SurugayaSessionProvider({ children }: { children: ReactNode }) {
     setIsFetching(true);
     setProgress(null);
     try {
-      await invoke('start_surugaya_mypage_fetch');
+      await invoke('start_surugaya_mypage_fetch', { forceRefetch: false });
+    } catch (error) {
+      setIsFetching(false);
+      throw error;
+    }
+  }, []);
+
+  const startRefetchAll = useCallback(async () => {
+    setIsFetching(true);
+    setProgress(null);
+    try {
+      await invoke('start_surugaya_mypage_fetch', { forceRefetch: true });
     } catch (error) {
       setIsFetching(false);
       throw error;
@@ -118,7 +129,14 @@ export function SurugayaSessionProvider({ children }: { children: ReactNode }) {
 
   return (
     <SurugayaSessionContext.Provider
-      value={{ isFetching, progress, openLoginWindow, startFetch, cancelFetch }}
+      value={{
+        isFetching,
+        progress,
+        openLoginWindow,
+        startFetch,
+        startRefetchAll,
+        cancelFetch,
+      }}
     >
       {children}
     </SurugayaSessionContext.Provider>


### PR DESCRIPTION
## Summary

- 駿河屋マイページのHTMLフェッチとパース処理をAmazonと同様に分離
- `surugaya_session`: WebViewでのHTMLフェッチと`html_content`保存のみ担当
- `parsers/surugaya_html_parse_task`: `SurugayaHtmlParseTask`（`BatchTask`実装）を新設
- `parse_orchestrator`: メールパース後に駿河屋→Amazon の順でHTMLパースを自動実行
- フェッチに差分取得（デフォルト）と全件再取得モードを追加
- 一括パースパイプラインからHTMLフェッチを除外し、パース処理のみに整理

## 変更後のフロー

```
【手動・事前実行】
  5. 駿河屋マイページHTML取得（差分 or 全件再取得）
  6. Amazon注文詳細HTML取得（差分 or 全件再取得）

【一括パースパイプライン（ログイン不要・何度でも再実行可能）】
  ① メールパース（駿河屋・Amazon の保存済みHTMLパース含む）
  ② 商品名解析
  ③ 配送状況確認
```

## Test plan

- [ ] 駿河屋セッションウィンドウを開いてHTMLフェッチ（差分取得）が動作する
- [ ] 「全件再取得」で取得済みURLも再フェッチされる
- [ ] メールパース実行時に駿河屋・Amazon の保存済みHTMLが自動パースされる
- [ ] 一括パースパイプラインが3ステップ（パース→商品名解析→配送確認）で完了する

🤖 Generated with [Claude Code](https://claude.com/claude-code)