### PR TITLE
feat: Amazon配達完了メールのパースに対応

### DIFF
--- a/src-tauri/src/plugins/amazon/mod.rs
+++ b/src-tauri/src/plugins/amazon/mod.rs
@@ -170,8 +170,7 @@ async fn dispatch_delivery_complete(
     body: &str,
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
 ) -> Result<DispatchOutcome, DispatchError> {
-    let info =
-        parsers::delivery_complete::parse(body).map_err(DispatchError::ParseFailed)?;
+    let info = parsers::delivery_complete::parse(body).map_err(DispatchError::ParseFailed)?;
 
     log::debug!(
         "[amazon_delivery_complete] email_id={} order_number={}",

--- a/src-tauri/src/plugins/amazon/mod.rs
+++ b/src-tauri/src/plugins/amazon/mod.rs
@@ -1,11 +1,16 @@
 //! Amazon.co.jp プラグイン
 //!
-//! Amazon.co.jp からの注文確認メールをパースして保存する。
+//! Amazon.co.jp からの注文確認メール・配達完了メールをパースして保存する。
 //!
-//! # 対応フォーマット
+//! # 対応フォーマット（注文確認）
 //! - 新フォーマット（件名: `注文済み:`）
 //! - 旧フォーマット・単一注文（件名: `Amazon.co.jp ご注文の確認`）
 //! - 旧フォーマット・複数注文（件名: `Amazon.co.jpでのご注文`）
+//!
+//! # 対応フォーマット（配達完了）
+//! - 件名: `ご注文商品はお住まいの建物内の宅配ボックスに配達しました。`
+//! - 件名: `配達完了:` / `配達完了：`
+//! - 件名: `配達済み:` / `配達済み：`
 
 pub mod html_parser;
 pub mod parsers;
@@ -24,7 +29,7 @@ pub struct AmazonPlugin;
 #[async_trait]
 impl VendorPlugin for AmazonPlugin {
     fn parser_types(&self) -> &[&str] {
-        &["amazon_confirm"]
+        &["amazon_confirm", "amazon_delivery_complete"]
     }
 
     fn priority(&self) -> i32 {
@@ -47,16 +52,30 @@ impl VendorPlugin for AmazonPlugin {
     }
 
     fn default_shop_settings(&self) -> Vec<DefaultShopSetting> {
-        vec![DefaultShopSetting {
-            shop_name: "Amazon.co.jp".to_string(),
-            sender_address: "auto-confirm@amazon.co.jp".to_string(),
-            parser_type: "amazon_confirm".to_string(),
-            subject_filters: Some(vec![
-                "Amazon.co.jp ご注文の確認".to_string(),
-                "Amazon.co.jpでのご注文".to_string(),
-                "注文済み:".to_string(),
-            ]),
-        }]
+        vec![
+            DefaultShopSetting {
+                shop_name: "Amazon.co.jp".to_string(),
+                sender_address: "auto-confirm@amazon.co.jp".to_string(),
+                parser_type: "amazon_confirm".to_string(),
+                subject_filters: Some(vec![
+                    "Amazon.co.jp ご注文の確認".to_string(),
+                    "Amazon.co.jpでのご注文".to_string(),
+                    "注文済み:".to_string(),
+                ]),
+            },
+            DefaultShopSetting {
+                shop_name: "Amazon.co.jp".to_string(),
+                sender_address: "order-update@amazon.co.jp".to_string(),
+                parser_type: "amazon_delivery_complete".to_string(),
+                subject_filters: Some(vec![
+                    "ご注文商品はお住まいの建物内の宅配ボックスに配達しました".to_string(),
+                    "配達完了:".to_string(),
+                    "配達完了：".to_string(),
+                    "配達済み:".to_string(),
+                    "配達済み：".to_string(),
+                ]),
+            },
+        ]
     }
 
     async fn dispatch(
@@ -69,6 +88,10 @@ impl VendorPlugin for AmazonPlugin {
         body: &str,
         tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     ) -> Result<DispatchOutcome, DispatchError> {
+        if parser_type == "amazon_delivery_complete" {
+            return dispatch_delivery_complete(email_id, body, tx).await;
+        }
+
         if parser_type != "amazon_confirm" {
             return Err(DispatchError::ParseFailed(format!(
                 "amazon: 未対応の parser_type '{parser_type}'"
@@ -141,6 +164,98 @@ impl VendorPlugin for AmazonPlugin {
     }
 }
 
+/// Amazon 配達完了メールを処理する
+async fn dispatch_delivery_complete(
+    email_id: i64,
+    body: &str,
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+) -> Result<DispatchOutcome, DispatchError> {
+    let info =
+        parsers::delivery_complete::parse(body).map_err(DispatchError::ParseFailed)?;
+
+    log::debug!(
+        "[amazon_delivery_complete] email_id={} order_number={}",
+        email_id,
+        info.order_number,
+    );
+
+    // 注文番号で orders を検索
+    let order: Option<(i64,)> =
+        sqlx::query_as("SELECT id FROM orders WHERE order_number = ? LIMIT 1")
+            .bind(&info.order_number)
+            .fetch_optional(tx.as_mut())
+            .await
+            .map_err(|e| DispatchError::SaveFailed(format!("DB error: {e}")))?;
+
+    let Some((order_id,)) = order else {
+        log::warn!(
+            "[amazon_delivery_complete] 注文番号に対応する order が未登録: order_number={}",
+            info.order_number,
+        );
+        return Ok(DispatchOutcome::DeliveryCompleted {
+            tracking_number: info.order_number,
+        });
+    };
+
+    // deliveries の有無を確認
+    let delivery: Option<(i64,)> =
+        sqlx::query_as("SELECT id FROM deliveries WHERE order_id = ? LIMIT 1")
+            .bind(order_id)
+            .fetch_optional(tx.as_mut())
+            .await
+            .map_err(|e| DispatchError::SaveFailed(format!("DB error: {e}")))?;
+
+    if let Some((delivery_id,)) = delivery {
+        // 既存レコードを更新
+        sqlx::query(
+            r#"
+            UPDATE deliveries
+            SET delivery_status = 'delivered',
+                actual_delivery = ?,
+                last_checked_at = CURRENT_TIMESTAMP,
+                updated_at      = CURRENT_TIMESTAMP
+            WHERE id = ?
+            "#,
+        )
+        .bind(info.delivered_at.as_deref())
+        .bind(delivery_id)
+        .execute(tx.as_mut())
+        .await
+        .map_err(|e| DispatchError::SaveFailed(format!("Failed to update deliveries: {e}")))?;
+
+        log::info!(
+            "[amazon_delivery_complete] updated: order_number={} delivery_id={}",
+            info.order_number,
+            delivery_id,
+        );
+    } else {
+        // Amazon は注文確認メール時点では delivery レコードを作成しないため、ここで新規作成する
+        sqlx::query(
+            r#"
+            INSERT INTO deliveries
+                (order_id, delivery_status, actual_delivery, last_checked_at)
+            VALUES
+                (?, 'delivered', ?, CURRENT_TIMESTAMP)
+            "#,
+        )
+        .bind(order_id)
+        .bind(info.delivered_at.as_deref())
+        .execute(tx.as_mut())
+        .await
+        .map_err(|e| DispatchError::SaveFailed(format!("Failed to insert deliveries: {e}")))?;
+
+        log::info!(
+            "[amazon_delivery_complete] inserted: order_number={} order_id={}",
+            info.order_number,
+            order_id,
+        );
+    }
+
+    Ok(DispatchOutcome::DeliveryCompleted {
+        tracking_number: info.order_number,
+    })
+}
+
 /// Amazon 注文詳細ページの URL を組み立てる
 fn order_detail_url(order_number: &str) -> String {
     format!(
@@ -161,6 +276,7 @@ mod tests {
     fn test_amazon_plugin_parser_types() {
         let plugin = AmazonPlugin;
         assert!(plugin.parser_types().contains(&"amazon_confirm"));
+        assert!(plugin.parser_types().contains(&"amazon_delivery_complete"));
     }
 
     #[test]
@@ -171,16 +287,25 @@ mod tests {
     #[test]
     fn test_amazon_default_shop_settings() {
         let settings = AmazonPlugin.default_shop_settings();
-        assert_eq!(settings.len(), 1);
+        assert_eq!(settings.len(), 2);
 
-        let s = &settings[0];
-        assert_eq!(s.sender_address, "auto-confirm@amazon.co.jp");
-        assert_eq!(s.parser_type, "amazon_confirm");
-
-        let filters = s.subject_filters.as_ref().unwrap();
+        let confirm = &settings[0];
+        assert_eq!(confirm.sender_address, "auto-confirm@amazon.co.jp");
+        assert_eq!(confirm.parser_type, "amazon_confirm");
+        let filters = confirm.subject_filters.as_ref().unwrap();
         assert!(filters.contains(&"Amazon.co.jp ご注文の確認".to_string()));
         assert!(filters.contains(&"Amazon.co.jpでのご注文".to_string()));
         assert!(filters.contains(&"注文済み:".to_string()));
+
+        let delivery = &settings[1];
+        assert_eq!(delivery.sender_address, "order-update@amazon.co.jp");
+        assert_eq!(delivery.parser_type, "amazon_delivery_complete");
+        let df = delivery.subject_filters.as_ref().unwrap();
+        assert!(df.contains(&"配達完了:".to_string()));
+        assert!(df.contains(&"配達完了：".to_string()));
+        assert!(df.contains(&"配達済み:".to_string()));
+        assert!(df.contains(&"配達済み：".to_string()));
+        assert!(df.iter().any(|f| f.contains("宅配ボックス")));
     }
 
     #[test]

--- a/src-tauri/src/plugins/amazon/parsers/delivery_complete.rs
+++ b/src-tauri/src/plugins/amazon/parsers/delivery_complete.rs
@@ -1,0 +1,159 @@
+//! Amazon.co.jp「配達完了」メール用パーサー
+//!
+//! 送信元: order-update@amazon.co.jp
+//!
+//! 対応件名:
+//! - `ご注文商品はお住まいの建物内の宅配ボックスに配達しました。`
+//! - `配達完了:` / `配達完了：`
+//! - `配達済み:` / `配達済み：`
+//!
+//! 本文から注文番号（例: `503-1234567-1234567`）を抽出する。
+
+use regex::Regex;
+
+/// Amazon 配達完了メールのパース結果
+#[derive(Debug, PartialEq)]
+pub struct AmazonDeliveryInfo {
+    /// 注文番号（例: 503-1234567-1234567）
+    pub order_number: String,
+    /// 配達完了日時（SQLite DATETIME 形式: "YYYY-MM-DD HH:MM:00"）があれば
+    pub delivered_at: Option<String>,
+}
+
+/// Amazon 配達完了メールをパースする
+pub fn parse(body: &str) -> Result<AmazonDeliveryInfo, String> {
+    let order_number =
+        extract_order_number(body).ok_or_else(|| "注文番号が見つかりません".to_string())?;
+    let delivered_at = extract_delivered_at(body);
+    Ok(AmazonDeliveryInfo {
+        order_number,
+        delivered_at,
+    })
+}
+
+/// 本文から Amazon 注文番号（NNN-NNNNNNN-NNNNNNN）を抽出する
+fn extract_order_number(body: &str) -> Option<String> {
+    let re = Regex::new(r"\b(\d{3}-\d{7}-\d{7})\b").ok()?;
+    re.captures(body)
+        .map(|cap| cap[1].to_string())
+}
+
+/// 本文から配達日時を抽出し "YYYY-MM-DD HH:MM:00" に変換する
+///
+/// 対応フォーマット例:
+/// - `2026/04/12 14:30`
+/// - `2026年4月12日 14:30`
+fn extract_delivered_at(body: &str) -> Option<String> {
+    // YYYY/MM/DD HH:MM 形式
+    let re_slash =
+        Regex::new(r"(\d{4})/(\d{1,2})/(\d{1,2})[^\d]+(\d{2}):(\d{2})").ok()?;
+    if let Some(cap) = re_slash.captures(body) {
+        return Some(format!(
+            "{}-{:02}-{:02} {}:{}:00",
+            &cap[1],
+            cap[2].parse::<u32>().unwrap_or(0),
+            cap[3].parse::<u32>().unwrap_or(0),
+            &cap[4],
+            &cap[5],
+        ));
+    }
+
+    // YYYY年M月D日 HH:MM 形式
+    let re_kanji =
+        Regex::new(r"(\d{4})年(\d{1,2})月(\d{1,2})日[^\d]+(\d{2}):(\d{2})").ok()?;
+    if let Some(cap) = re_kanji.captures(body) {
+        return Some(format!(
+            "{}-{:02}-{:02} {}:{}:00",
+            &cap[1],
+            cap[2].parse::<u32>().unwrap_or(0),
+            cap[3].parse::<u32>().unwrap_or(0),
+            &cap[4],
+            &cap[5],
+        ));
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_BODY_TAKUHAI: &str = "\
+Amazon.co.jp
+
+山田 太郎 様
+
+ご注文商品はお住まいの建物内の宅配ボックスに配達しました。
+
+注文番号: 503-1234567-1234567
+配達日時: 2026/04/12 14:30
+
+ご利用ありがとうございました。
+";
+
+    const SAMPLE_BODY_DELIVERED: &str = "\
+Amazon.co.jp
+
+山田 太郎 様
+
+配達完了: ご注文が配達されました。
+
+ご注文番号
+250-9876543-7654321
+
+お届け日: 2026年4月10日 09:05
+
+詳細はAmazonのウェブサイトでご確認ください。
+";
+
+    const SAMPLE_BODY_NO_DATE: &str = "\
+Amazon.co.jp
+
+配達済み：
+
+注文番号: 112-1111111-2222222
+
+お届け先: 東京都...
+";
+
+    #[test]
+    fn test_parse_takuhai_box() {
+        let result = parse(SAMPLE_BODY_TAKUHAI).unwrap();
+        assert_eq!(result.order_number, "503-1234567-1234567");
+        assert_eq!(result.delivered_at, Some("2026-04-12 14:30:00".to_string()));
+    }
+
+    #[test]
+    fn test_parse_delivered_kanji_date() {
+        let result = parse(SAMPLE_BODY_DELIVERED).unwrap();
+        assert_eq!(result.order_number, "250-9876543-7654321");
+        assert_eq!(result.delivered_at, Some("2026-04-10 09:05:00".to_string()));
+    }
+
+    #[test]
+    fn test_parse_no_date() {
+        let result = parse(SAMPLE_BODY_NO_DATE).unwrap();
+        assert_eq!(result.order_number, "112-1111111-2222222");
+        assert_eq!(result.delivered_at, None);
+    }
+
+    #[test]
+    fn test_parse_no_order_number() {
+        let body = "配達が完了しました。詳細はサイトをご確認ください。";
+        assert!(parse(body).is_err());
+    }
+
+    #[test]
+    fn test_extract_order_number_various() {
+        assert_eq!(
+            extract_order_number("注文番号: 503-1234567-1234567"),
+            Some("503-1234567-1234567".to_string())
+        );
+        assert_eq!(
+            extract_order_number("250-0000001-9999999 のご注文"),
+            Some("250-0000001-9999999".to_string())
+        );
+        assert_eq!(extract_order_number("注文なし"), None);
+    }
+}

--- a/src-tauri/src/plugins/amazon/parsers/delivery_complete.rs
+++ b/src-tauri/src/plugins/amazon/parsers/delivery_complete.rs
@@ -34,8 +34,7 @@ pub fn parse(body: &str) -> Result<AmazonDeliveryInfo, String> {
 /// 本文から Amazon 注文番号（NNN-NNNNNNN-NNNNNNN）を抽出する
 fn extract_order_number(body: &str) -> Option<String> {
     let re = Regex::new(r"\b(\d{3}-\d{7}-\d{7})\b").ok()?;
-    re.captures(body)
-        .map(|cap| cap[1].to_string())
+    re.captures(body).map(|cap| cap[1].to_string())
 }
 
 /// 本文から配達日時を抽出し "YYYY-MM-DD HH:MM:00" に変換する
@@ -45,8 +44,7 @@ fn extract_order_number(body: &str) -> Option<String> {
 /// - `2026年4月12日 14:30`
 fn extract_delivered_at(body: &str) -> Option<String> {
     // YYYY/MM/DD HH:MM 形式
-    let re_slash =
-        Regex::new(r"(\d{4})/(\d{1,2})/(\d{1,2})[^\d]+(\d{2}):(\d{2})").ok()?;
+    let re_slash = Regex::new(r"(\d{4})/(\d{1,2})/(\d{1,2})[^\d]+(\d{2}):(\d{2})").ok()?;
     if let Some(cap) = re_slash.captures(body) {
         return Some(format!(
             "{}-{:02}-{:02} {}:{}:00",
@@ -59,8 +57,7 @@ fn extract_delivered_at(body: &str) -> Option<String> {
     }
 
     // YYYY年M月D日 HH:MM 形式
-    let re_kanji =
-        Regex::new(r"(\d{4})年(\d{1,2})月(\d{1,2})日[^\d]+(\d{2}):(\d{2})").ok()?;
+    let re_kanji = Regex::new(r"(\d{4})年(\d{1,2})月(\d{1,2})日[^\d]+(\d{2}):(\d{2})").ok()?;
     if let Some(cap) = re_kanji.captures(body) {
         return Some(format!(
             "{}-{:02}-{:02} {}:{}:00",

--- a/src-tauri/src/plugins/amazon/parsers/mod.rs
+++ b/src-tauri/src/plugins/amazon/parsers/mod.rs
@@ -1,1 +1,2 @@
 pub mod confirm;
+pub mod delivery_complete;


### PR DESCRIPTION
## Summary

- `order-update@amazon.co.jp` からの配達完了通知メールに対応する `amazon_delivery_complete` パーサーを追加
- 対応件名: `ご注文商品はお住まいの建物内の宅配ボックスに配達しました。` / `配達完了:` / `配達完了：` / `配達済み:` / `配達済み：`
- Amazon は注文確認メール時点で `deliveries` レコードを作成しないため、配達完了メール処理時に未登録の場合は新規 INSERT する設計を採用

## Changes

- `plugins/amazon/parsers/delivery_complete.rs` (新規): メール本文から注文番号・配達日時を抽出するパーサー
- `plugins/amazon/mod.rs`: `amazon_delivery_complete` parser_type の登録・dispatch処理・shop_settings追加
- `plugins/amazon/parsers/mod.rs`: モジュール追加

## Test plan

- [ ] `cargo test` が全件通過すること
- [ ] パース実行後、`order-update@amazon.co.jp` のメールに対応する `deliveries` レコードが `delivery_status = 'delivered'` で作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)