### PR TITLE
feat: Amazon HTMLパースでキャンセル済み注文を検出・適用

### DIFF
--- a/src-tauri/src/parsers/html_parse_task.rs
+++ b/src-tauri/src/parsers/html_parse_task.rs
@@ -63,13 +63,24 @@ impl BatchTask for HtmlParseTask {
         let order_number = extract_order_id_from_url(&input.url)
             .ok_or_else(|| format!("Cannot extract orderID from URL: {}", input.url))?;
 
-        let order_info = html_parser::parse_order_detail_html(&input.html_content, &order_number)?;
-
         let mut tx = ctx
             .pool
             .begin()
             .await
             .map_err(|e| format!("Failed to begin tx: {e}"))?;
+
+        if html_parser::is_cancelled_order(&input.html_content) {
+            apply_cancelled_order(&mut tx, &order_number).await?;
+            tx.commit()
+                .await
+                .map_err(|e| format!("Failed to commit: {e}"))?;
+            return Ok(HtmlParseOutput {
+                html_id: input.html_id,
+                order_number,
+            });
+        }
+
+        let order_info = html_parser::parse_order_detail_html(&input.html_content, &order_number)?;
 
         SqliteOrderRepository::save_order_in_tx(
             &mut tx,
@@ -89,6 +100,57 @@ impl BatchTask for HtmlParseTask {
             order_number,
         })
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// キャンセル処理
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// キャンセル済み HTML の処理: 既存注文のアイテムを削除し配送ステータスを更新する
+async fn apply_cancelled_order(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    order_number: &str,
+) -> Result<(), String> {
+    let order: Option<(i64,)> =
+        sqlx::query_as("SELECT id FROM orders WHERE order_number = ? AND shop_domain = 'amazon.co.jp' LIMIT 1")
+            .bind(order_number)
+            .fetch_optional(tx.as_mut())
+            .await
+            .map_err(|e| format!("DB error: {e}"))?;
+
+    let Some((order_id,)) = order else {
+        log::warn!(
+            "[html_parse] キャンセル済み注文が未登録: order_number={}",
+            order_number
+        );
+        return Ok(());
+    };
+
+    sqlx::query("DELETE FROM items WHERE order_id = ?")
+        .bind(order_id)
+        .execute(tx.as_mut())
+        .await
+        .map_err(|e| format!("Failed to delete items: {e}"))?;
+
+    sqlx::query(
+        r#"
+        UPDATE deliveries
+        SET delivery_status = 'cancelled', updated_at = CURRENT_TIMESTAMP
+        WHERE order_id = ?
+        "#,
+    )
+    .bind(order_id)
+    .execute(tx.as_mut())
+    .await
+    .map_err(|e| format!("Failed to update deliveries: {e}"))?;
+
+    log::info!(
+        "[html_parse] キャンセル適用: order_number={} order_id={}",
+        order_number,
+        order_id
+    );
+
+    Ok(())
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src-tauri/src/parsers/html_parse_task.rs
+++ b/src-tauri/src/parsers/html_parse_task.rs
@@ -111,12 +111,13 @@ async fn apply_cancelled_order(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     order_number: &str,
 ) -> Result<(), String> {
-    let order: Option<(i64,)> =
-        sqlx::query_as("SELECT id FROM orders WHERE order_number = ? AND shop_domain = 'amazon.co.jp' LIMIT 1")
-            .bind(order_number)
-            .fetch_optional(tx.as_mut())
-            .await
-            .map_err(|e| format!("DB error: {e}"))?;
+    let order: Option<(i64,)> = sqlx::query_as(
+        "SELECT id FROM orders WHERE order_number = ? AND shop_domain = 'amazon.co.jp' LIMIT 1",
+    )
+    .bind(order_number)
+    .fetch_optional(tx.as_mut())
+    .await
+    .map_err(|e| format!("DB error: {e}"))?;
 
     let Some((order_id,)) = order else {
         log::warn!(

--- a/src-tauri/src/plugins/amazon/html_parser.rs
+++ b/src-tauri/src/plugins/amazon/html_parser.rs
@@ -14,6 +14,13 @@ use crate::parsers::{OrderInfo, OrderItem};
 // パース関数
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Amazon 注文詳細 HTML がキャンセル済み注文を表しているか判定する
+///
+/// "キャンセル済み" の表示が含まれるページはキャンセルとして扱う。
+pub fn is_cancelled_order(html: &str) -> bool {
+    html.contains("キャンセル済み") || html.contains("注文のキャンセルが完了")
+}
+
 /// Amazon 注文詳細 HTML をパースして `OrderInfo` を返す
 ///
 /// `order_number` は URL の `orderID` パラメータから呼び出し元で抽出して渡す。
@@ -350,6 +357,24 @@ mod tests {
     #[test]
     fn test_parse_quantity_none() {
         assert_eq!(parse_quantity_from_text("no quantity"), None);
+    }
+
+    #[test]
+    fn test_is_cancelled_order_true() {
+        let html = "<html><body><span>キャンセル済み</span></body></html>";
+        assert!(is_cancelled_order(html));
+    }
+
+    #[test]
+    fn test_is_cancelled_order_completion_text() {
+        let html = "<html><body>注文のキャンセルが完了しました</body></html>";
+        assert!(is_cancelled_order(html));
+    }
+
+    #[test]
+    fn test_is_cancelled_order_false() {
+        let html = "<html><body><div class=\"yohtmlc-item\">商品A</div></body></html>";
+        assert!(!is_cancelled_order(html));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `html_parser.rs` に `is_cancelled_order()` を追加: HTMLに「キャンセル済み」または「注文のキャンセルが完了」が含まれる場合に `true` を返す
- `html_parse_task.rs` でキャンセル判定を行い、キャンセル済みなら既存注文の `items` を全削除・`deliveries.delivery_status` を `cancelled` に更新
- 注文がDBに未登録の場合は警告ログを出してスキップ（エラーにしない）

## Test plan

- [ ] `is_cancelled_order` のユニットテスト3件追加済み（`cargo test` で確認）
- [ ] キャンセル済みHTMLを含む注文でHTMLパースを実行し、アイテムが削除されることを確認
- [ ] 通常注文のHTMLパースが引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)