### PR TITLE
feat: ヨドバシ・ドット・コム 注文確認メールのパーサーを追加

### DIFF
--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -380,6 +380,13 @@ mod tests {
     }
 
     #[test]
+    fn test_find_plugin_yodobashi_cancel() {
+        let registry = build_registry();
+        let plugin = find_plugin(&registry, "yodobashi_cancel");
+        assert!(plugin.is_some());
+    }
+
+    #[test]
     fn test_find_plugin_unknown_returns_none() {
         let registry = build_registry();
         let plugin = find_plugin(&registry, "unknown_parser");

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -22,6 +22,7 @@ pub mod premium_bandai;
 pub mod sagawa;
 pub mod surugaya;
 pub mod surugaya_mp;
+pub mod yodobashi;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // inventory による自動登録
@@ -368,6 +369,13 @@ mod tests {
     fn test_find_plugin_amazon_confirm() {
         let registry = build_registry();
         let plugin = find_plugin(&registry, "amazon_confirm");
+        assert!(plugin.is_some());
+    }
+
+    #[test]
+    fn test_find_plugin_yodobashi_confirm() {
+        let registry = build_registry();
+        let plugin = find_plugin(&registry, "yodobashi_confirm");
         assert!(plugin.is_some());
     }
 

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -387,6 +387,13 @@ mod tests {
     }
 
     #[test]
+    fn test_find_plugin_yodobashi_send() {
+        let registry = build_registry();
+        let plugin = find_plugin(&registry, "yodobashi_send");
+        assert!(plugin.is_some());
+    }
+
+    #[test]
     fn test_find_plugin_unknown_returns_none() {
         let registry = build_registry();
         let plugin = find_plugin(&registry, "unknown_parser");

--- a/src-tauri/src/plugins/yodobashi/mod.rs
+++ b/src-tauri/src/plugins/yodobashi/mod.rs
@@ -1,6 +1,7 @@
 //! ヨドバシ・ドット・コムプラグイン
 //!
-//! `thanks_gochuumon@yodobashi.com` から配信される注文確認メールをパースする。
+//! - 注文確認: `thanks_gochuumon@yodobashi.com`
+//! - キャンセル: `cancel@yodobashi.com`
 
 pub mod parsers;
 
@@ -19,7 +20,7 @@ pub struct YodobashiPlugin;
 #[async_trait]
 impl VendorPlugin for YodobashiPlugin {
     fn parser_types(&self) -> &[&str] {
-        &["yodobashi_confirm"]
+        &["yodobashi_confirm", "yodobashi_cancel"]
     }
 
     fn priority(&self) -> i32 {
@@ -28,9 +29,7 @@ impl VendorPlugin for YodobashiPlugin {
 
     fn get_parser(&self, parser_type: &str) -> Option<Box<dyn EmailParser>> {
         match parser_type {
-            "yodobashi_confirm" => {
-                Some(Box::new(parsers::confirm::YodobashiConfirmParser))
-            }
+            "yodobashi_confirm" => Some(Box::new(parsers::confirm::YodobashiConfirmParser)),
             _ => None,
         }
     }
@@ -44,14 +43,24 @@ impl VendorPlugin for YodobashiPlugin {
     }
 
     fn default_shop_settings(&self) -> Vec<DefaultShopSetting> {
-        vec![DefaultShopSetting {
-            shop_name: "ヨドバシ・ドット・コム".to_string(),
-            sender_address: "thanks_gochuumon@yodobashi.com".to_string(),
-            parser_type: "yodobashi_confirm".to_string(),
-            subject_filters: Some(vec![
-                "ヨドバシ・ドット・コム：ご注文ありがとうございます".to_string(),
-            ]),
-        }]
+        vec![
+            DefaultShopSetting {
+                shop_name: "ヨドバシ・ドット・コム".to_string(),
+                sender_address: "thanks_gochuumon@yodobashi.com".to_string(),
+                parser_type: "yodobashi_confirm".to_string(),
+                subject_filters: Some(vec![
+                    "ヨドバシ・ドット・コム：ご注文ありがとうございます".to_string(),
+                ]),
+            },
+            DefaultShopSetting {
+                shop_name: "ヨドバシ・ドット・コム".to_string(),
+                sender_address: "cancel@yodobashi.com".to_string(),
+                parser_type: "yodobashi_cancel".to_string(),
+                subject_filters: Some(vec![
+                    "ヨドバシ・ドット・コム：ご注文内容変更のご連絡".to_string(),
+                ]),
+            },
+        ]
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -67,31 +76,66 @@ impl VendorPlugin for YodobashiPlugin {
     ) -> Result<DispatchOutcome, DispatchError> {
         let shop_domain = derive_shop_domain(from_address);
 
-        let order_info = {
-            let parser = self.get_parser(parser_type).ok_or_else(|| {
-                DispatchError::ParseFailed(format!("No parser for type: {}", parser_type))
-            })?;
-            parser.parse(body).map_err(DispatchError::ParseFailed)?
-        };
+        match parser_type {
+            "yodobashi_cancel" => {
+                let cancel_infos = parsers::cancel::YodobashiCancelParser
+                    .parse_cancel(body)
+                    .map_err(DispatchError::ParseFailed)?;
 
-        log::debug!(
-            "[{}] email_id={} order_number={}",
-            parser_type,
-            email_id,
-            order_info.order_number
-        );
+                let order_number = cancel_infos[0].order_number.clone();
 
-        SqliteOrderRepository::save_order_in_tx(
-            tx,
-            &order_info,
-            Some(email_id),
-            shop_domain,
-            Some(shop_name.to_string()),
-        )
-        .await
-        .map_err(DispatchError::SaveFailed)?;
+                log::debug!(
+                    "[yodobashi_cancel] email_id={} order_number={} items={}",
+                    email_id,
+                    order_number,
+                    cancel_infos.len()
+                );
 
-        Ok(DispatchOutcome::OrderSaved(Box::new(order_info)))
+                // 複数商品が個別にキャンセルされる場合があるため商品ごとに適用する
+                for cancel_info in &cancel_infos {
+                    SqliteOrderRepository::apply_cancel_in_tx(
+                        tx,
+                        cancel_info,
+                        email_id,
+                        shop_domain.clone(),
+                        None,
+                    )
+                    .await
+                    .map_err(DispatchError::SaveFailed)?;
+                }
+
+                Ok(DispatchOutcome::CancelApplied { order_number })
+            }
+
+            _ => {
+                // yodobashi_confirm およびその他
+                let order_info = {
+                    let parser = self.get_parser(parser_type).ok_or_else(|| {
+                        DispatchError::ParseFailed(format!("No parser for type: {}", parser_type))
+                    })?;
+                    parser.parse(body).map_err(DispatchError::ParseFailed)?
+                };
+
+                log::debug!(
+                    "[{}] email_id={} order_number={}",
+                    parser_type,
+                    email_id,
+                    order_info.order_number
+                );
+
+                SqliteOrderRepository::save_order_in_tx(
+                    tx,
+                    &order_info,
+                    Some(email_id),
+                    shop_domain,
+                    Some(shop_name.to_string()),
+                )
+                .await
+                .map_err(DispatchError::SaveFailed)?;
+
+                Ok(DispatchOutcome::OrderSaved(Box::new(order_info)))
+            }
+        }
     }
 }
 

--- a/src-tauri/src/plugins/yodobashi/mod.rs
+++ b/src-tauri/src/plugins/yodobashi/mod.rs
@@ -20,7 +20,7 @@ pub struct YodobashiPlugin;
 #[async_trait]
 impl VendorPlugin for YodobashiPlugin {
     fn parser_types(&self) -> &[&str] {
-        &["yodobashi_confirm", "yodobashi_cancel"]
+        &["yodobashi_confirm", "yodobashi_cancel", "yodobashi_send"]
     }
 
     fn priority(&self) -> i32 {
@@ -30,6 +30,7 @@ impl VendorPlugin for YodobashiPlugin {
     fn get_parser(&self, parser_type: &str) -> Option<Box<dyn EmailParser>> {
         match parser_type {
             "yodobashi_confirm" => Some(Box::new(parsers::confirm::YodobashiConfirmParser)),
+            "yodobashi_send" => Some(Box::new(parsers::send::YodobashiSendParser)),
             _ => None,
         }
     }
@@ -58,6 +59,14 @@ impl VendorPlugin for YodobashiPlugin {
                 parser_type: "yodobashi_cancel".to_string(),
                 subject_filters: Some(vec![
                     "ヨドバシ・ドット・コム：ご注文内容変更のご連絡".to_string()
+                ]),
+            },
+            DefaultShopSetting {
+                shop_name: "ヨドバシ・ドット・コム".to_string(),
+                sender_address: "otodoke@yodobashi.com".to_string(),
+                parser_type: "yodobashi_send".to_string(),
+                subject_filters: Some(vec![
+                    "ヨドバシ・ドット・コム：ご注文商品出荷のお知らせ".to_string()
                 ]),
             },
         ]

--- a/src-tauri/src/plugins/yodobashi/mod.rs
+++ b/src-tauri/src/plugins/yodobashi/mod.rs
@@ -1,0 +1,100 @@
+//! ヨドバシ・ドット・コムプラグイン
+//!
+//! `thanks_gochuumon@yodobashi.com` から配信される注文確認メールをパースする。
+
+pub mod parsers;
+
+use async_trait::async_trait;
+
+use crate::parsers::EmailParser;
+use crate::repository::SqliteOrderRepository;
+
+use super::{
+    derive_shop_domain, DefaultShopSetting, DispatchError, DispatchOutcome, PluginRegistration,
+    VendorPlugin,
+};
+
+pub struct YodobashiPlugin;
+
+#[async_trait]
+impl VendorPlugin for YodobashiPlugin {
+    fn parser_types(&self) -> &[&str] {
+        &["yodobashi_confirm"]
+    }
+
+    fn priority(&self) -> i32 {
+        10
+    }
+
+    fn get_parser(&self, parser_type: &str) -> Option<Box<dyn EmailParser>> {
+        match parser_type {
+            "yodobashi_confirm" => {
+                Some(Box::new(parsers::confirm::YodobashiConfirmParser))
+            }
+            _ => None,
+        }
+    }
+
+    fn prefer_plain_text(&self) -> bool {
+        true
+    }
+
+    fn shop_name(&self) -> &str {
+        "ヨドバシ・ドット・コム"
+    }
+
+    fn default_shop_settings(&self) -> Vec<DefaultShopSetting> {
+        vec![DefaultShopSetting {
+            shop_name: "ヨドバシ・ドット・コム".to_string(),
+            sender_address: "thanks_gochuumon@yodobashi.com".to_string(),
+            parser_type: "yodobashi_confirm".to_string(),
+            subject_filters: Some(vec![
+                "ヨドバシ・ドット・コム：ご注文ありがとうございます".to_string(),
+            ]),
+        }]
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch(
+        &self,
+        parser_type: &str,
+        email_id: i64,
+        from_address: Option<&str>,
+        shop_name: &str,
+        _internal_date: Option<i64>,
+        body: &str,
+        tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    ) -> Result<DispatchOutcome, DispatchError> {
+        let shop_domain = derive_shop_domain(from_address);
+
+        let order_info = {
+            let parser = self.get_parser(parser_type).ok_or_else(|| {
+                DispatchError::ParseFailed(format!("No parser for type: {}", parser_type))
+            })?;
+            parser.parse(body).map_err(DispatchError::ParseFailed)?
+        };
+
+        log::debug!(
+            "[{}] email_id={} order_number={}",
+            parser_type,
+            email_id,
+            order_info.order_number
+        );
+
+        SqliteOrderRepository::save_order_in_tx(
+            tx,
+            &order_info,
+            Some(email_id),
+            shop_domain,
+            Some(shop_name.to_string()),
+        )
+        .await
+        .map_err(DispatchError::SaveFailed)?;
+
+        Ok(DispatchOutcome::OrderSaved(Box::new(order_info)))
+    }
+}
+
+inventory::submit!(PluginRegistration {
+    factory: || Box::new(YodobashiPlugin),
+});

--- a/src-tauri/src/plugins/yodobashi/mod.rs
+++ b/src-tauri/src/plugins/yodobashi/mod.rs
@@ -49,7 +49,7 @@ impl VendorPlugin for YodobashiPlugin {
                 sender_address: "thanks_gochuumon@yodobashi.com".to_string(),
                 parser_type: "yodobashi_confirm".to_string(),
                 subject_filters: Some(vec![
-                    "ヨドバシ・ドット・コム：ご注文ありがとうございます".to_string(),
+                    "ヨドバシ・ドット・コム：ご注文ありがとうございます".to_string()
                 ]),
             },
             DefaultShopSetting {
@@ -57,7 +57,7 @@ impl VendorPlugin for YodobashiPlugin {
                 sender_address: "cancel@yodobashi.com".to_string(),
                 parser_type: "yodobashi_cancel".to_string(),
                 subject_filters: Some(vec![
-                    "ヨドバシ・ドット・コム：ご注文内容変更のご連絡".to_string(),
+                    "ヨドバシ・ドット・コム：ご注文内容変更のご連絡".to_string()
                 ]),
             },
         ]

--- a/src-tauri/src/plugins/yodobashi/parsers/cancel.rs
+++ b/src-tauri/src/plugins/yodobashi/parsers/cancel.rs
@@ -1,0 +1,220 @@
+//! ヨドバシ・ドット・コム 注文キャンセルメール用パーサー
+//!
+//! 件名：`ヨドバシ・ドット・コム：ご注文内容変更のご連絡`
+//! 送信元：`cancel@yodobashi.com`
+//!
+//! `【キャンセル対象のご注文商品】` セクションから注文番号・キャンセル商品リストを抽出する。
+//! 1通のメールで複数商品がキャンセルされる場合があるため `Vec<CancelInfo>` を返す。
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use crate::parsers::cancel_info::CancelInfo;
+
+pub struct YodobashiCancelParser;
+
+// ─── 正規表現 ────────────────────────────────────────────────────────────────
+
+/// `【変更対象のご注文番号】 7538892732`
+static ORDER_NUMBER_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"【変更対象のご注文番号】\s*(\d+)").expect("ORDER_NUMBER_RE")
+});
+
+/// キャンセルセクションの数量・価格行
+/// `　　1 点　   880 円` → trimmed: `1 点　   880 円`
+static CANCEL_QTY_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^(\d+)\s*点\s+([\d,]+)\s*円").expect("CANCEL_QTY_RE"));
+
+// ─── ヘルパー ─────────────────────────────────────────────────────────────────
+
+fn extract_order_number(body: &str) -> Option<String> {
+    ORDER_NUMBER_RE
+        .captures(body)
+        .map(|c| c[1].trim().to_string())
+}
+
+/// `【キャンセル対象のご注文商品】` セクションからキャンセル商品リストを抽出する
+///
+/// 商品名の折り返し形式は confirm メールと同じ。
+/// 数量行は `合計` プレフィックスなし（`N 点　X,XXX 円`）。
+/// `・配達料金：` または `◎【変更前】` でセクション終了。
+fn extract_cancel_items(body: &str) -> Vec<(String, i64)> {
+    let mut items: Vec<(String, i64)> = Vec::new();
+    let mut in_cancel_section = false;
+    let mut current_name: Option<String> = None;
+    let mut collecting_name = false;
+
+    for line in body.lines() {
+        let trimmed = line.trim();
+
+        if trimmed == "【キャンセル対象のご注文商品】" {
+            in_cancel_section = true;
+            continue;
+        }
+
+        if !in_cancel_section {
+            continue;
+        }
+
+        // セクション終了
+        if trimmed.starts_with("・配達料金") || trimmed.starts_with("◎【変更前】") {
+            break;
+        }
+
+        // 商品名の折り返し行を収集中
+        if collecting_name {
+            if let Some(ref mut name) = current_name {
+                if let Some(rest) = trimmed.strip_suffix('」') {
+                    name.push_str(rest);
+                    collecting_name = false;
+                } else {
+                    name.push_str(trimmed);
+                }
+            }
+            continue;
+        }
+
+        // 商品名行の開始
+        if let Some(after) = trimmed.strip_prefix("・「") {
+            if let Some(name) = after.strip_suffix('」') {
+                current_name = Some(name.trim().to_string());
+            } else {
+                current_name = Some(after.to_string());
+                collecting_name = true;
+            }
+            continue;
+        }
+
+        // 数量・価格行（`N 点　X,XXX 円`）
+        if let Some(caps) = CANCEL_QTY_RE.captures(trimmed) {
+            if let Some(name) = current_name.take() {
+                let quantity: i64 = caps[1].parse().unwrap_or(1);
+                items.push((name, quantity));
+            }
+            continue;
+        }
+    }
+
+    items
+}
+
+// ─── パブリック API ───────────────────────────────────────────────────────────
+
+impl YodobashiCancelParser {
+    /// メール本文からキャンセル情報のリストを抽出する
+    ///
+    /// 複数商品がキャンセルされている場合は複数の `CancelInfo` を返す。
+    /// キャンセル商品が見つからない場合はエラーを返す。
+    pub fn parse_cancel(&self, email_body: &str) -> Result<Vec<CancelInfo>, String> {
+        let order_number = extract_order_number(email_body)
+            .ok_or_else(|| "注文番号が見つかりません".to_string())?;
+
+        let items = extract_cancel_items(email_body);
+        if items.is_empty() {
+            return Err("キャンセル対象商品が見つかりません".to_string());
+        }
+
+        let cancel_infos = items
+            .into_iter()
+            .map(|(product_name, cancel_quantity)| CancelInfo {
+                order_number: order_number.clone(),
+                product_name,
+                cancel_quantity,
+            })
+            .collect();
+
+        Ok(cancel_infos)
+    }
+}
+
+// ─── テスト ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_cancel() -> &'static str {
+        r#"【変更対象のご注文番号】 7538892732
+─────────────────────────────
+●変更ご依頼内容：
+　　注文商品の一部キャンセル
+─────────────────────────────
+
+◎【変更後】のご注文内容
+─────────────────────────────
+●ご注文商品
+---------------------------------------------------------------
+・「データ用CD-R 700MB ひろびろワイドレーベル 10枚 エコパッケージ CD
+　　R700S.SWPS.10E」
+　　配達希望日：2026年02月24日
+　　合計 1 点　   587 円
+・配達料金：　　0 円
+
+【キャンセル対象のご注文商品】
+---------------------------------------------------------------
+・「SDHCメモリーカード 16GB Class10 UHS-I U1 最大読込40MB/s RSDC-016
+　　GU1S」
+　　1 点　   880 円
+・「SDHCカード 16GB Class10 UHS-I U1 最大読込70MB/s 最大書込70MB/s H
+　　DSDH16GCL10UIJP3」
+　　1 点　   880 円
+・配達料金：　　0 円
+
+◎【変更前】のご注文内容
+─────────────────────────────
+"#
+    }
+
+    #[test]
+    fn test_parse_cancel_order_number() {
+        let infos = YodobashiCancelParser.parse_cancel(sample_cancel()).unwrap();
+        assert!(infos.iter().all(|i| i.order_number == "7538892732"));
+    }
+
+    #[test]
+    fn test_parse_cancel_item_count() {
+        let infos = YodobashiCancelParser.parse_cancel(sample_cancel()).unwrap();
+        assert_eq!(infos.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_cancel_item_names() {
+        let infos = YodobashiCancelParser.parse_cancel(sample_cancel()).unwrap();
+        // 折り返し部分が連結されていること
+        assert!(infos[0].product_name.contains("SDHCメモリーカード"));
+        assert!(infos[0].product_name.contains("GU1S"));
+        assert!(infos[1].product_name.contains("SDHCカード"));
+        assert!(infos[1].product_name.contains("DSDH16GCL10UIJP3"));
+    }
+
+    #[test]
+    fn test_parse_cancel_quantities() {
+        let infos = YodobashiCancelParser.parse_cancel(sample_cancel()).unwrap();
+        assert_eq!(infos[0].cancel_quantity, 1);
+        assert_eq!(infos[1].cancel_quantity, 1);
+    }
+
+    #[test]
+    fn test_parse_cancel_no_order_number_returns_error() {
+        let result = YodobashiCancelParser.parse_cancel(
+            "【キャンセル対象のご注文商品】\n・「テスト商品」\n　　1 点　   880 円\n・配達料金：　　0 円",
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_cancel_no_items_returns_error() {
+        let result = YodobashiCancelParser
+            .parse_cancel("【変更対象のご注文番号】 7538892732\n【キャンセル対象のご注文商品】\n・配達料金：　　0 円");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_cancel_does_not_pick_up_non_cancel_section_items() {
+        // 「◎【変更後】のご注文内容」の商品はキャンセル対象ではない
+        let infos = YodobashiCancelParser.parse_cancel(sample_cancel()).unwrap();
+        assert!(!infos
+            .iter()
+            .any(|i| i.product_name.contains("データ用CD-R")));
+    }
+}

--- a/src-tauri/src/plugins/yodobashi/parsers/cancel.rs
+++ b/src-tauri/src/plugins/yodobashi/parsers/cancel.rs
@@ -16,9 +16,8 @@ pub struct YodobashiCancelParser;
 // ─── 正規表現 ────────────────────────────────────────────────────────────────
 
 /// `【変更対象のご注文番号】 7538892732`
-static ORDER_NUMBER_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"【変更対象のご注文番号】\s*(\d+)").expect("ORDER_NUMBER_RE")
-});
+static ORDER_NUMBER_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"【変更対象のご注文番号】\s*(\d+)").expect("ORDER_NUMBER_RE"));
 
 /// キャンセルセクションの数量・価格行
 /// `　　1 点　   880 円` → trimmed: `1 点　   880 円`

--- a/src-tauri/src/plugins/yodobashi/parsers/confirm.rs
+++ b/src-tauri/src/plugins/yodobashi/parsers/confirm.rs
@@ -1,0 +1,359 @@
+//! ヨドバシ・ドット・コム 注文確認メール用パーサー
+//!
+//! 件名：`ヨドバシ・ドット・コム：ご注文ありがとうございます`
+//! 送信元：`thanks_gochuumon@yodobashi.com`
+//!
+//! プレーンテキスト形式。
+//! 注文日はメール本文に含まれるため `apply_internal_date` は不要。
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use crate::parsers::{EmailParser, OrderInfo, OrderItem};
+
+pub struct YodobashiConfirmParser;
+
+// ─── 正規表現 ────────────────────────────────────────────────────────────────
+
+/// `【ご注文番号】 7224945594`
+static ORDER_NUMBER_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"【ご注文番号】\s*(\d+)").expect("ORDER_NUMBER_RE"));
+
+/// `・ご注文日　　　　　　　　　　　2019年06月12日`
+static ORDER_DATE_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"ご注文日\s*(\d{4})年(\d{2})月(\d{2})日").expect("ORDER_DATE_RE"));
+
+/// `【ご注文金額】今回のお買い物合計金額　　　　      2,527 円`
+///
+/// `[^\d]+` で数字以外を読み飛ばし、最初の数字グループを合計金額として取得する。
+static TOTAL_AMOUNT_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"【ご注文金額】[^\d]+([\d,]+)\s*円").expect("TOTAL_AMOUNT_RE")
+});
+
+/// `合計 1 点　   1,900 円` → (数量, 小計)
+static ITEM_TOTAL_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"合計\s+(\d+)\s*点\s+([\d,]+)\s*円").expect("ITEM_TOTAL_RE"));
+
+/// `・配達料金：　　0 円`
+static SHIPPING_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"・配達料金：\s*([\d,]+)\s*円").expect("SHIPPING_RE"));
+
+// ─── ヘルパー ─────────────────────────────────────────────────────────────────
+
+fn parse_amount(s: &str) -> i64 {
+    s.replace(',', "").trim().parse().unwrap_or(0)
+}
+
+/// `2019年06月12日` → `"2019-06-12 00:00:00"`
+fn parse_yodobashi_date(year: &str, month: &str, day: &str) -> String {
+    format!("{}-{}-{} 00:00:00", year, month, day)
+}
+
+// ─── 各フィールドの抽出 ───────────────────────────────────────────────────────
+
+fn extract_order_number(body: &str) -> Option<String> {
+    ORDER_NUMBER_RE
+        .captures(body)
+        .map(|c| c[1].trim().to_string())
+}
+
+fn extract_order_date(body: &str) -> Option<String> {
+    ORDER_DATE_RE
+        .captures(body)
+        .map(|c| parse_yodobashi_date(&c[1], &c[2], &c[3]))
+}
+
+fn extract_total_amount(body: &str) -> Option<i64> {
+    TOTAL_AMOUNT_RE
+        .captures(body)
+        .map(|c| parse_amount(&c[1]))
+}
+
+fn extract_shipping_fee(body: &str) -> Option<i64> {
+    SHIPPING_RE
+        .captures(body)
+        .map(|c| parse_amount(&c[1]))
+}
+
+/// `【ご注文商品】` セクションから商品リストを抽出する
+///
+/// 各商品ブロック：
+/// ```text
+/// ・「商品名（長い場合は次行に折り返される）
+/// 　　折り返し部分」
+///
+/// 　　配達希望日：YYYY年MM月DD日
+///
+/// 　　合計 N 点　   X,XXX 円
+/// ```
+/// `・配達料金：` または `【お支払方法】` でセクション終了。
+fn extract_items(body: &str) -> Vec<OrderItem> {
+    let mut items: Vec<OrderItem> = Vec::new();
+    let mut in_items_section = false;
+    let mut current_name: Option<String> = None;
+    let mut collecting_name = false; // 商品名が複数行に折り返されている途中
+
+    for line in body.lines() {
+        let trimmed = line.trim();
+
+        if trimmed == "【ご注文商品】" {
+            in_items_section = true;
+            continue;
+        }
+
+        if !in_items_section {
+            continue;
+        }
+
+        // セクション終了条件（名前収集中でも優先）
+        if trimmed.starts_with("・配達料金") || trimmed.starts_with("【お支払方法】") {
+            break;
+        }
+
+        // 商品名の折り返し行を収集中
+        if collecting_name {
+            if let Some(ref mut name) = current_name {
+                if let Some(rest) = trimmed.strip_suffix('」') {
+                    // 折り返しの最終行：名前確定
+                    name.push_str(rest);
+                    collecting_name = false;
+                } else {
+                    // さらに続く行（3行以上の折り返し）
+                    name.push_str(trimmed);
+                }
+            }
+            continue;
+        }
+
+        // 商品名行の開始（・「...」 または ・「...（折り返し）
+        if let Some(after) = trimmed.strip_prefix("・「") {
+            if let Some(name) = after.strip_suffix('」') {
+                // 1行に収まっている
+                current_name = Some(name.trim().to_string());
+            } else {
+                // 複数行に折り返されている
+                current_name = Some(after.to_string());
+                collecting_name = true;
+            }
+            continue;
+        }
+
+        // 合計行（数量 + 小計）
+        if let Some(caps) = ITEM_TOTAL_RE.captures(trimmed) {
+            if let Some(name) = current_name.take() {
+                let quantity: i64 = caps[1].parse().unwrap_or(1);
+                let subtotal = parse_amount(&caps[2]);
+                let unit_price = if quantity > 0 { subtotal / quantity } else { subtotal };
+                items.push(OrderItem {
+                    name,
+                    manufacturer: None,
+                    model_number: None,
+                    unit_price,
+                    quantity,
+                    subtotal,
+                    image_url: None,
+                });
+            }
+            continue;
+        }
+    }
+
+    items
+}
+
+// ─── EmailParser ─────────────────────────────────────────────────────────────
+
+impl EmailParser for YodobashiConfirmParser {
+    fn parse(&self, email_body: &str) -> Result<OrderInfo, String> {
+        let order_number = extract_order_number(email_body)
+            .ok_or_else(|| "注文番号が見つかりません".to_string())?;
+
+        let items = extract_items(email_body);
+        if items.is_empty() {
+            return Err("商品情報が見つかりません".to_string());
+        }
+
+        let order_date = extract_order_date(email_body);
+        let shipping_fee = extract_shipping_fee(email_body);
+        let total_amount = extract_total_amount(email_body);
+
+        // 小計 = 各商品 subtotal の合算
+        let subtotal: i64 = items.iter().map(|i| i.subtotal).sum();
+
+        Ok(OrderInfo {
+            order_number,
+            order_date,
+            delivery_address: None,
+            delivery_info: None,
+            items,
+            subtotal: Some(subtotal),
+            shipping_fee,
+            total_amount,
+        })
+    }
+}
+
+// ─── テスト ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_confirm() -> &'static str {
+        r#"==========================================================
+■■ご注文ありがとうございます■■
+　　（このメールは、配信専用のアドレスで配信されています）
+==========================================================
+ヨドバシ・ドット・コムをご利用いただき、ありがとうございます。
+下記の内容でご注文を承りました。
+（表示の価格は、すべて消費税総額表示です）
+
+【ご注文番号】 7224945594
+---------------------------------------------------------------
+・ご注文主のお名前　　　　　　　テスト 太郎 様
+・ご注文日　　　　　　　　　　　2019年06月12日
+
+・お届け先のお名前　　　　　　　テスト 太郎 様
+・商品のお届け先　　　　　　　　東京都テスト市テスト町1-1
+
+【ご注文金額】今回のお買い物合計金額　　　　      2,527 円
+---------------------------------------------------------------
+・クレジットカードでのお支払い　　          2,527 円
+
+【ご注文商品】
+---------------------------------------------------------------
+・「SS-07 [シンプルフォン]」
+
+　　配達希望日：2019年06月13日
+
+　　合計 1 点　   1,900 円
+
+・「ペペ オーガニック 360ml」
+
+　　配達希望日：2019年06月13日
+
+　　合計 1 点　   627 円
+
+・配達料金：　　0 円
+
+【お支払方法】クレジットカード
+---------------------------------------------------------------
+"#
+    }
+
+    #[test]
+    fn test_parse_order_number() {
+        let order = YodobashiConfirmParser.parse(sample_confirm()).unwrap();
+        assert_eq!(order.order_number, "7224945594");
+    }
+
+    #[test]
+    fn test_parse_order_date() {
+        let order = YodobashiConfirmParser.parse(sample_confirm()).unwrap();
+        assert_eq!(order.order_date, Some("2019-06-12 00:00:00".to_string()));
+    }
+
+    #[test]
+    fn test_parse_item_count() {
+        let order = YodobashiConfirmParser.parse(sample_confirm()).unwrap();
+        assert_eq!(order.items.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_item_names() {
+        let order = YodobashiConfirmParser.parse(sample_confirm()).unwrap();
+        assert_eq!(order.items[0].name, "SS-07 [シンプルフォン]");
+        assert_eq!(order.items[1].name, "ペペ オーガニック 360ml");
+    }
+
+    #[test]
+    fn test_parse_item_quantities() {
+        let order = YodobashiConfirmParser.parse(sample_confirm()).unwrap();
+        assert_eq!(order.items[0].quantity, 1);
+        assert_eq!(order.items[1].quantity, 1);
+    }
+
+    #[test]
+    fn test_parse_item_prices() {
+        let order = YodobashiConfirmParser.parse(sample_confirm()).unwrap();
+        assert_eq!(order.items[0].unit_price, 1900);
+        assert_eq!(order.items[0].subtotal, 1900);
+        assert_eq!(order.items[1].unit_price, 627);
+        assert_eq!(order.items[1].subtotal, 627);
+    }
+
+    #[test]
+    fn test_parse_shipping_fee() {
+        let order = YodobashiConfirmParser.parse(sample_confirm()).unwrap();
+        assert_eq!(order.shipping_fee, Some(0));
+    }
+
+    #[test]
+    fn test_parse_total_amount() {
+        let order = YodobashiConfirmParser.parse(sample_confirm()).unwrap();
+        assert_eq!(order.total_amount, Some(2527));
+    }
+
+    #[test]
+    fn test_parse_subtotal() {
+        let order = YodobashiConfirmParser.parse(sample_confirm()).unwrap();
+        // 1,900 + 627 = 2,527
+        assert_eq!(order.subtotal, Some(2527));
+    }
+
+    fn sample_confirm_wrapped() -> &'static str {
+        // 商品名が2行に折り返されているケース（メール2234相当）
+        r#"【ご注文番号】 7538892732
+・ご注文日　　　　　　　　　　　2026年02月23日
+【ご注文金額】今回のお買い物合計金額　　　　      4,487 円
+【ご注文商品】
+-------
+・「データ用CD-R 700MB ひろびろワイドレーベル 10枚 エコパッケージ CD
+　　R700S.SWPS.10E」
+
+　　合計 1 点　   587 円
+
+・「EXCERIA BASIC microSDHCカード 32GB Class10 UHS-I U1 最大読込50MB
+　　/s KMUB-A032G」
+
+　　合計 1 点　   1,070 円
+
+・配達料金：　　0 円
+"#
+    }
+
+    #[test]
+    fn test_parse_wrapped_item_count() {
+        let order = YodobashiConfirmParser.parse(sample_confirm_wrapped()).unwrap();
+        assert_eq!(order.items.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_wrapped_item_names() {
+        let order = YodobashiConfirmParser.parse(sample_confirm_wrapped()).unwrap();
+        // 折り返し部分が連結されていること
+        assert!(order.items[0].name.contains("データ用CD-R"));
+        assert!(order.items[0].name.contains("R700S.SWPS.10E"));
+        assert!(order.items[1].name.contains("EXCERIA BASIC microSDHCカード"));
+        assert!(order.items[1].name.contains("KMUB-A032G"));
+    }
+
+    #[test]
+    fn test_parse_wrapped_item_prices() {
+        let order = YodobashiConfirmParser.parse(sample_confirm_wrapped()).unwrap();
+        assert_eq!(order.items[0].subtotal, 587);
+        assert_eq!(order.items[1].subtotal, 1070);
+    }
+
+    #[test]
+    fn test_parse_no_order_number_returns_error() {
+        let result = YodobashiConfirmParser.parse("ご注文ありがとうございます。\n【ご注文商品】\n・「テスト商品」\n\n　　合計 1 点　   1,000 円\n・配達料金：　　0 円");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_no_items_returns_error() {
+        let result = YodobashiConfirmParser.parse("【ご注文番号】 1234567890\n【ご注文商品】\n・配達料金：　　0 円");
+        assert!(result.is_err());
+    }
+}

--- a/src-tauri/src/plugins/yodobashi/parsers/confirm.rs
+++ b/src-tauri/src/plugins/yodobashi/parsers/confirm.rs
@@ -26,9 +26,8 @@ static ORDER_DATE_RE: Lazy<Regex> =
 /// `【ご注文金額】今回のお買い物合計金額　　　　      2,527 円`
 ///
 /// `[^\d]+` で数字以外を読み飛ばし、最初の数字グループを合計金額として取得する。
-static TOTAL_AMOUNT_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"【ご注文金額】[^\d]+([\d,]+)\s*円").expect("TOTAL_AMOUNT_RE")
-});
+static TOTAL_AMOUNT_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"【ご注文金額】[^\d]+([\d,]+)\s*円").expect("TOTAL_AMOUNT_RE"));
 
 /// `合計 1 点　   1,900 円` → (数量, 小計)
 static ITEM_TOTAL_RE: Lazy<Regex> =
@@ -64,15 +63,11 @@ fn extract_order_date(body: &str) -> Option<String> {
 }
 
 fn extract_total_amount(body: &str) -> Option<i64> {
-    TOTAL_AMOUNT_RE
-        .captures(body)
-        .map(|c| parse_amount(&c[1]))
+    TOTAL_AMOUNT_RE.captures(body).map(|c| parse_amount(&c[1]))
 }
 
 fn extract_shipping_fee(body: &str) -> Option<i64> {
-    SHIPPING_RE
-        .captures(body)
-        .map(|c| parse_amount(&c[1]))
+    SHIPPING_RE.captures(body).map(|c| parse_amount(&c[1]))
 }
 
 /// `【ご注文商品】` セクションから商品リストを抽出する
@@ -143,7 +138,11 @@ fn extract_items(body: &str) -> Vec<OrderItem> {
             if let Some(name) = current_name.take() {
                 let quantity: i64 = caps[1].parse().unwrap_or(1);
                 let subtotal = parse_amount(&caps[2]);
-                let unit_price = if quantity > 0 { subtotal / quantity } else { subtotal };
+                let unit_price = if quantity > 0 {
+                    subtotal / quantity
+                } else {
+                    subtotal
+                };
                 items.push(OrderItem {
                     name,
                     manufacturer: None,
@@ -324,23 +323,31 @@ mod tests {
 
     #[test]
     fn test_parse_wrapped_item_count() {
-        let order = YodobashiConfirmParser.parse(sample_confirm_wrapped()).unwrap();
+        let order = YodobashiConfirmParser
+            .parse(sample_confirm_wrapped())
+            .unwrap();
         assert_eq!(order.items.len(), 2);
     }
 
     #[test]
     fn test_parse_wrapped_item_names() {
-        let order = YodobashiConfirmParser.parse(sample_confirm_wrapped()).unwrap();
+        let order = YodobashiConfirmParser
+            .parse(sample_confirm_wrapped())
+            .unwrap();
         // 折り返し部分が連結されていること
         assert!(order.items[0].name.contains("データ用CD-R"));
         assert!(order.items[0].name.contains("R700S.SWPS.10E"));
-        assert!(order.items[1].name.contains("EXCERIA BASIC microSDHCカード"));
+        assert!(order.items[1]
+            .name
+            .contains("EXCERIA BASIC microSDHCカード"));
         assert!(order.items[1].name.contains("KMUB-A032G"));
     }
 
     #[test]
     fn test_parse_wrapped_item_prices() {
-        let order = YodobashiConfirmParser.parse(sample_confirm_wrapped()).unwrap();
+        let order = YodobashiConfirmParser
+            .parse(sample_confirm_wrapped())
+            .unwrap();
         assert_eq!(order.items[0].subtotal, 587);
         assert_eq!(order.items[1].subtotal, 1070);
     }
@@ -353,7 +360,8 @@ mod tests {
 
     #[test]
     fn test_parse_no_items_returns_error() {
-        let result = YodobashiConfirmParser.parse("【ご注文番号】 1234567890\n【ご注文商品】\n・配達料金：　　0 円");
+        let result = YodobashiConfirmParser
+            .parse("【ご注文番号】 1234567890\n【ご注文商品】\n・配達料金：　　0 円");
         assert!(result.is_err());
     }
 }

--- a/src-tauri/src/plugins/yodobashi/parsers/mod.rs
+++ b/src-tauri/src/plugins/yodobashi/parsers/mod.rs
@@ -1,0 +1,1 @@
+pub mod confirm;

--- a/src-tauri/src/plugins/yodobashi/parsers/mod.rs
+++ b/src-tauri/src/plugins/yodobashi/parsers/mod.rs
@@ -1,2 +1,3 @@
 pub mod cancel;
 pub mod confirm;
+pub mod send;

--- a/src-tauri/src/plugins/yodobashi/parsers/mod.rs
+++ b/src-tauri/src/plugins/yodobashi/parsers/mod.rs
@@ -1,1 +1,2 @@
+pub mod cancel;
 pub mod confirm;

--- a/src-tauri/src/plugins/yodobashi/parsers/send.rs
+++ b/src-tauri/src/plugins/yodobashi/parsers/send.rs
@@ -1,0 +1,426 @@
+//! ヨドバシ・ドット・コム 発送通知メール用パーサー
+//!
+//! 件名：`ヨドバシ・ドット・コム：ご注文商品出荷のお知らせ`
+//! 送信元：`otodoke@yodobashi.com`
+//!
+//! 対応配送業者：ヤマト運輸・日本郵便 ゆうパック・ヨドバシエクストリームサービス便・当社専用便
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use crate::parsers::{DeliveryInfo, EmailParser, OrderInfo, OrderItem};
+
+pub struct YodobashiSendParser;
+
+// ─── 正規表現 ────────────────────────────────────────────────────────────────
+
+/// `【ご注文番号】 7224945594`
+static ORDER_NUMBER_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"【ご注文番号】\s*(\d+)").expect("ORDER_NUMBER_RE"));
+
+/// `・ご注文日　　　　　　　　　　　2019年06月12日`
+static ORDER_DATE_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"ご注文日\s*(\d{4})年(\d{2})月(\d{2})日").expect("ORDER_DATE_RE"));
+
+/// `【ご注文金額】今回出荷のお買い物合計金額　　　　2,527 円`
+static TOTAL_AMOUNT_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"【ご注文金額】[^\d]+([\d,]+)\s*円").expect("TOTAL_AMOUNT_RE"));
+
+/// 出荷商品セクションの数量・価格行
+/// `　 　 1 点　1,900 円` → trimmed: `1 点　1,900 円`
+static ITEM_QTY_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^(\d+)\s*点\s+([\d,]+)\s*円").expect("ITEM_QTY_RE"));
+
+/// `・配達料金：　　0 円`
+static SHIPPING_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"・配達料金：\s*([\d,]+)\s*円").expect("SHIPPING_RE"));
+
+/// `【配達について】今回の配達：ヤマト運輸 宅急便`
+/// `【配達について】今回の配達担当：ヨドバシエクストリームサービス便`
+static CARRIER_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"【配達について】今回の配達(?:担当)?：(.+)").expect("CARRIER_RE"));
+
+/// `配達受付番号（伝票番号）：335065497546`
+static TRACKING_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"配達受付番号（伝票番号）：(\d+)").expect("TRACKING_RE"));
+
+// ─── ヘルパー ─────────────────────────────────────────────────────────────────
+
+fn parse_amount(s: &str) -> i64 {
+    s.replace(',', "").trim().parse().unwrap_or(0)
+}
+
+fn parse_yodobashi_date(year: &str, month: &str, day: &str) -> String {
+    format!("{}-{}-{} 00:00:00", year, month, day)
+}
+
+fn extract_order_number(body: &str) -> Option<String> {
+    ORDER_NUMBER_RE
+        .captures(body)
+        .map(|c| c[1].trim().to_string())
+}
+
+fn extract_order_date(body: &str) -> Option<String> {
+    ORDER_DATE_RE
+        .captures(body)
+        .map(|c| parse_yodobashi_date(&c[1], &c[2], &c[3]))
+}
+
+fn extract_total_amount(body: &str) -> Option<i64> {
+    TOTAL_AMOUNT_RE.captures(body).map(|c| parse_amount(&c[1]))
+}
+
+fn extract_shipping_fee(body: &str) -> Option<i64> {
+    SHIPPING_RE.captures(body).map(|c| parse_amount(&c[1]))
+}
+
+fn extract_carrier(body: &str) -> Option<String> {
+    CARRIER_RE.captures(body).map(|c| c[1].trim().to_string())
+}
+
+fn extract_tracking_number(body: &str) -> Option<String> {
+    TRACKING_RE.captures(body).map(|c| c[1].trim().to_string())
+}
+
+/// `▼ヤマト運輸ホームページ` または `▼日本郵便ホームページ` の次行にある追跡 URL を抽出する
+fn extract_carrier_url(body: &str) -> Option<String> {
+    let mut next_is_url = false;
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if next_is_url {
+            if trimmed.starts_with("http") {
+                return Some(trimmed.to_string());
+            }
+            // 空行はスキップ、それ以外はリセット
+            if !trimmed.is_empty() {
+                next_is_url = false;
+            }
+        }
+        if trimmed.starts_with('▼') && trimmed.ends_with("ホームページ") {
+            next_is_url = true;
+        }
+    }
+    None
+}
+
+/// `【今回出荷の商品】` セクションから商品リストを抽出する
+///
+/// 数量行は confirm の `合計 N 点` と異なり `N 点　X,XXX 円` 形式。
+/// 商品名の折り返しは confirm・cancel と同形式。
+/// `・配達料金：` または `【` で始まる次セクションでセクション終了。
+fn extract_shipped_items(body: &str) -> Vec<OrderItem> {
+    let mut items: Vec<OrderItem> = Vec::new();
+    let mut in_section = false;
+    let mut current_name: Option<String> = None;
+    let mut collecting_name = false;
+
+    for line in body.lines() {
+        let trimmed = line.trim();
+
+        if trimmed == "【今回出荷の商品】" {
+            in_section = true;
+            continue;
+        }
+
+        if !in_section {
+            continue;
+        }
+
+        // セクション終了
+        if trimmed.starts_with("・配達料金")
+            || (trimmed.starts_with('【') && trimmed != "【今回出荷の商品】")
+        {
+            break;
+        }
+
+        // 商品名の折り返し行を収集中
+        if collecting_name {
+            if let Some(ref mut name) = current_name {
+                if let Some(rest) = trimmed.strip_suffix('」') {
+                    name.push_str(rest);
+                    collecting_name = false;
+                } else {
+                    name.push_str(trimmed);
+                }
+            }
+            continue;
+        }
+
+        // 商品名行
+        if let Some(after) = trimmed.strip_prefix("・「") {
+            if let Some(name) = after.strip_suffix('」') {
+                current_name = Some(name.trim().to_string());
+            } else {
+                current_name = Some(after.to_string());
+                collecting_name = true;
+            }
+            continue;
+        }
+
+        // 数量・価格行（`N 点　X,XXX 円`）
+        if let Some(caps) = ITEM_QTY_RE.captures(trimmed) {
+            if let Some(name) = current_name.take() {
+                let quantity: i64 = caps[1].parse().unwrap_or(1);
+                let subtotal = parse_amount(&caps[2]);
+                let unit_price = if quantity > 0 {
+                    subtotal / quantity
+                } else {
+                    subtotal
+                };
+                items.push(OrderItem {
+                    name,
+                    manufacturer: None,
+                    model_number: None,
+                    unit_price,
+                    quantity,
+                    subtotal,
+                    image_url: None,
+                });
+            }
+            continue;
+        }
+    }
+
+    items
+}
+
+/// 配送情報を抽出する
+///
+/// 追跡番号がない業者（ヨドバシエクストリームサービス便・当社専用便）では
+/// `tracking_number` を空文字列とする。
+fn extract_delivery_info(body: &str) -> Option<DeliveryInfo> {
+    let carrier = extract_carrier(body)?;
+    let tracking_number = extract_tracking_number(body).unwrap_or_default();
+    let carrier_url = extract_carrier_url(body);
+
+    Some(DeliveryInfo {
+        carrier,
+        tracking_number,
+        delivery_date: None,
+        delivery_time: None,
+        carrier_url,
+        delivery_status: None,
+    })
+}
+
+// ─── EmailParser ─────────────────────────────────────────────────────────────
+
+impl EmailParser for YodobashiSendParser {
+    fn parse(&self, email_body: &str) -> Result<OrderInfo, String> {
+        let order_number = extract_order_number(email_body)
+            .ok_or_else(|| "注文番号が見つかりません".to_string())?;
+
+        let items = extract_shipped_items(email_body);
+        if items.is_empty() {
+            return Err("出荷商品が見つかりません".to_string());
+        }
+
+        let subtotal: i64 = items.iter().map(|i| i.subtotal).sum();
+
+        Ok(OrderInfo {
+            order_number,
+            order_date: extract_order_date(email_body),
+            delivery_address: None,
+            delivery_info: extract_delivery_info(email_body),
+            items,
+            subtotal: Some(subtotal),
+            shipping_fee: extract_shipping_fee(email_body),
+            total_amount: extract_total_amount(email_body),
+        })
+    }
+}
+
+// ─── テスト ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_yamato() -> &'static str {
+        r#"【ご注文番号】 7224945594
+・ご注文日　　　　　　　　　　　2019年06月12日
+
+【ご注文金額】今回出荷のお買い物合計金額　　　　2,527 円
+
+【今回出荷の商品】
+---------------------------------------------------------------
+・「SS-07 [シンプルフォン]」
+　 　 1 点　1,900 円
+・「ペペ オーガニック 360ml」
+　 　 1 点　627 円
+・配達料金：　　0 円
+
+【配達について】今回の配達：ヤマト運輸 宅急便
+---------------------------------------------------------------
+配達受付番号（伝票番号）：335065497546
+
+　▼ヤマト運輸ホームページ
+　　http://toi.kuronekoyamato.co.jp/cgi-bin/tneko?type=1&no01=335065497546
+"#
+    }
+
+    fn sample_japanpost() -> &'static str {
+        r#"【ご注文番号】 7466000284
+・ご注文日　　　　　　　　　　　2022年05月17日
+
+【ご注文金額】今回出荷のお買い物合計金額　　　　594 円
+
+【今回出荷の商品】
+---------------------------------------------------------------
+・「30 MINUTES MISSIONS 1/144 オプションパーツセット7 （カスタマイズ
+　　ヘッドB） [プラモデル用パーツ]」
+　 　 1 点　594 円
+・配達料金：　　0 円
+
+【配達について】今回の配達：日本郵便 ゆうパック
+---------------------------------------------------------------
+配達受付番号（伝票番号）：263823775762
+
+　▼日本郵便ホームページ
+　　http://tracking.post.japanpost.jp/service/singleSearch.do?searchKind=S002&reqCodeNo1=263823775762
+"#
+    }
+
+    fn sample_extreme() -> &'static str {
+        r#"【ご注文番号】 7234682517
+・ご注文日　　　　　　　　　　　2019年10月13日
+
+【ご注文金額】今回出荷のお買い物合計金額　　　　4,136 円
+
+【今回出荷の商品】
+---------------------------------------------------------------
+・「LB-L ピュアホワイト [ランドリーバスケット Lサイズ ピュアホワイト
+　　]」
+　 　 2 点　1,298 円
+・「81336596 [AC/DC・2WAYパワーブロー 4mロングDCコード/0.51PSI]」
+　 　 1 点　2,838 円
+・配達料金：　　0 円
+
+【配達会社指定サービス】
+---------------------------------------------------------------
+・ヨドバシエクストリームサービス便
+
+【配達について】今回の配達担当：ヨドバシエクストリームサービス便
+---------------------------------------------------------------
+"#
+    }
+
+    // ── ヤマト運輸 ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_yamato_order_number() {
+        let order = YodobashiSendParser.parse(sample_yamato()).unwrap();
+        assert_eq!(order.order_number, "7224945594");
+    }
+
+    #[test]
+    fn test_yamato_order_date() {
+        let order = YodobashiSendParser.parse(sample_yamato()).unwrap();
+        assert_eq!(order.order_date, Some("2019-06-12 00:00:00".to_string()));
+    }
+
+    #[test]
+    fn test_yamato_item_count() {
+        let order = YodobashiSendParser.parse(sample_yamato()).unwrap();
+        assert_eq!(order.items.len(), 2);
+    }
+
+    #[test]
+    fn test_yamato_item_names() {
+        let order = YodobashiSendParser.parse(sample_yamato()).unwrap();
+        assert_eq!(order.items[0].name, "SS-07 [シンプルフォン]");
+        assert_eq!(order.items[1].name, "ペペ オーガニック 360ml");
+    }
+
+    #[test]
+    fn test_yamato_item_prices() {
+        let order = YodobashiSendParser.parse(sample_yamato()).unwrap();
+        assert_eq!(order.items[0].unit_price, 1900);
+        assert_eq!(order.items[1].unit_price, 627);
+    }
+
+    #[test]
+    fn test_yamato_total_amount() {
+        let order = YodobashiSendParser.parse(sample_yamato()).unwrap();
+        assert_eq!(order.total_amount, Some(2527));
+    }
+
+    #[test]
+    fn test_yamato_shipping_fee() {
+        let order = YodobashiSendParser.parse(sample_yamato()).unwrap();
+        assert_eq!(order.shipping_fee, Some(0));
+    }
+
+    #[test]
+    fn test_yamato_carrier() {
+        let order = YodobashiSendParser.parse(sample_yamato()).unwrap();
+        let di = order.delivery_info.unwrap();
+        assert_eq!(di.carrier, "ヤマト運輸 宅急便");
+        assert_eq!(di.tracking_number, "335065497546");
+        assert!(di
+            .carrier_url
+            .as_deref()
+            .unwrap()
+            .contains("kuronekoyamato"));
+    }
+
+    // ── 日本郵便 ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_japanpost_carrier() {
+        let order = YodobashiSendParser.parse(sample_japanpost()).unwrap();
+        let di = order.delivery_info.unwrap();
+        assert_eq!(di.carrier, "日本郵便 ゆうパック");
+        assert_eq!(di.tracking_number, "263823775762");
+        assert!(di.carrier_url.as_deref().unwrap().contains("japanpost"));
+    }
+
+    #[test]
+    fn test_japanpost_wrapped_item_name() {
+        let order = YodobashiSendParser.parse(sample_japanpost()).unwrap();
+        assert!(order.items[0].name.contains("30 MINUTES MISSIONS"));
+        assert!(order.items[0].name.contains("ヘッドB"));
+    }
+
+    // ── ヨドバシエクストリームサービス便 ──────────────────────────────────────
+
+    #[test]
+    fn test_extreme_carrier() {
+        let order = YodobashiSendParser.parse(sample_extreme()).unwrap();
+        let di = order.delivery_info.unwrap();
+        assert_eq!(di.carrier, "ヨドバシエクストリームサービス便");
+        assert_eq!(di.tracking_number, ""); // 追跡番号なし
+        assert!(di.carrier_url.is_none());
+    }
+
+    #[test]
+    fn test_extreme_item_count() {
+        let order = YodobashiSendParser.parse(sample_extreme()).unwrap();
+        assert_eq!(order.items.len(), 2);
+    }
+
+    #[test]
+    fn test_extreme_item_quantity() {
+        let order = YodobashiSendParser.parse(sample_extreme()).unwrap();
+        assert_eq!(order.items[0].quantity, 2);
+        assert_eq!(order.items[0].subtotal, 1298);
+        assert_eq!(order.items[0].unit_price, 649);
+    }
+
+    // ── エラーケース ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_no_order_number_returns_error() {
+        let result = YodobashiSendParser.parse(
+            "【今回出荷の商品】\n・「テスト商品」\n　 　 1 点　1,000 円\n・配達料金：　　0 円",
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_no_items_returns_error() {
+        let result = YodobashiSendParser
+            .parse("【ご注文番号】 1234567890\n【今回出荷の商品】\n・配達料金：　　0 円");
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- `thanks_gochuumon@yodobashi.com` からの注文確認メール（件名：ヨドバシ・ドット・コム：ご注文ありがとうございます）に対応
- 注文番号・注文日・商品名・数量・金額・配達料金を抽出するパーサーを実装
- 商品名が長くて2行に折り返されるケースにも対応
- アプリ起動時に shop_settings へのデフォルト設定を自動登録

## Test plan

- [ ] 14件のユニットテストがすべてパスすること（`cargo test --lib plugins::yodobashi`）
- [ ] メール再パースでヨドバシ注文が DB に登録されること
- [ ] 商品名が折り返されているメール（ID: 2234）が正しくパースされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)