### PR TITLE
feat: バックアップ対象に htmls / news_clips / item_exclusion_patterns を追加

### DIFF
--- a/src-tauri/src/metadata/export.rs
+++ b/src-tauri/src/metadata/export.rs
@@ -177,9 +177,8 @@ where
         .map_err(|e| format!("Failed to serialize htmls: {e}"))?;
     let news_clips_json = serde_json::to_string_pretty(&news_clips_rows)
         .map_err(|e| format!("Failed to serialize news_clips: {e}"))?;
-    let item_exclusion_patterns_json =
-        serde_json::to_string_pretty(&item_exclusion_patterns_rows)
-            .map_err(|e| format!("Failed to serialize item_exclusion_patterns: {e}"))?;
+    let item_exclusion_patterns_json = serde_json::to_string_pretty(&item_exclusion_patterns_rows)
+        .map_err(|e| format!("Failed to serialize item_exclusion_patterns: {e}"))?;
 
     let manifest = Manifest {
         version: MANIFEST_VERSION,

--- a/src-tauri/src/metadata/export.rs
+++ b/src-tauri/src/metadata/export.rs
@@ -11,8 +11,9 @@ use zip::write::FileOptions;
 use super::file_safety::{copy_restore_point_zip, is_safe_file_name, RESTORE_POINT_FILE_NAME};
 use super::manifest::{Manifest, MANIFEST_VERSION, MAX_IMAGE_ENTRY_SIZE, MAX_NDJSON_LINE_SIZE};
 use super::table_converters::{
-    EmailRow, ExcludedItemRow, ExcludedOrderRow, ExportResult, ItemOverrideRow, OrderOverrideRow,
-    ProductMasterRow, ShopSettingsRow, TrackingCheckLogRow,
+    EmailRow, ExcludedItemRow, ExcludedOrderRow, ExportResult, HtmlsRow, ItemExclusionPatternRow,
+    ItemOverrideRow, NewsClipRow, OrderOverrideRow, ProductMasterRow, ShopSettingsRow,
+    TrackingCheckLogRow,
 };
 
 /// メタデータをZIPにエクスポート
@@ -128,6 +129,33 @@ where
     .await
     .map_err(|e| format!("Failed to fetch tracking_check_logs: {e}"))?;
 
+    let htmls_rows: Vec<HtmlsRow> = sqlx::query_as(
+        r#"
+        SELECT id, url, html_content, analysis_status, created_at, updated_at FROM htmls
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| format!("Failed to fetch htmls: {e}"))?;
+
+    let news_clips_rows: Vec<NewsClipRow> = sqlx::query_as(
+        r#"
+        SELECT id, title, url, source_name, published_at, summary, tags, clipped_at FROM news_clips
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| format!("Failed to fetch news_clips: {e}"))?;
+
+    let item_exclusion_patterns_rows: Vec<ItemExclusionPatternRow> = sqlx::query_as(
+        r#"
+        SELECT id, shop_domain, keyword, match_type, note, created_at FROM item_exclusion_patterns
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| format!("Failed to fetch item_exclusion_patterns: {e}"))?;
+
     // 2. JSON にシリアライズ（emails は後でストリーミング出力するため除外）
     let images_json = serde_json::to_string_pretty(&images_rows)
         .map_err(|e| format!("Failed to serialize images: {e}"))?;
@@ -145,6 +173,13 @@ where
         .map_err(|e| format!("Failed to serialize excluded_orders: {e}"))?;
     let tracking_check_logs_json = serde_json::to_string_pretty(&tracking_check_logs_rows)
         .map_err(|e| format!("Failed to serialize tracking_check_logs: {e}"))?;
+    let htmls_json = serde_json::to_string_pretty(&htmls_rows)
+        .map_err(|e| format!("Failed to serialize htmls: {e}"))?;
+    let news_clips_json = serde_json::to_string_pretty(&news_clips_rows)
+        .map_err(|e| format!("Failed to serialize news_clips: {e}"))?;
+    let item_exclusion_patterns_json =
+        serde_json::to_string_pretty(&item_exclusion_patterns_rows)
+            .map_err(|e| format!("Failed to serialize item_exclusion_patterns: {e}"))?;
 
     let manifest = Manifest {
         version: MANIFEST_VERSION,
@@ -224,6 +259,27 @@ where
     zip_writer
         .write_all(tracking_check_logs_json.as_bytes())
         .map_err(|e| format!("Failed to write tracking_check_logs: {e}"))?;
+
+    zip_writer
+        .start_file("htmls.json", options)
+        .map_err(|e| format!("Failed to add htmls.json: {e}"))?;
+    zip_writer
+        .write_all(htmls_json.as_bytes())
+        .map_err(|e| format!("Failed to write htmls: {e}"))?;
+
+    zip_writer
+        .start_file("news_clips.json", options)
+        .map_err(|e| format!("Failed to add news_clips.json: {e}"))?;
+    zip_writer
+        .write_all(news_clips_json.as_bytes())
+        .map_err(|e| format!("Failed to write news_clips: {e}"))?;
+
+    zip_writer
+        .start_file("item_exclusion_patterns.json", options)
+        .map_err(|e| format!("Failed to add item_exclusion_patterns.json: {e}"))?;
+    zip_writer
+        .write_all(item_exclusion_patterns_json.as_bytes())
+        .map_err(|e| format!("Failed to write item_exclusion_patterns: {e}"))?;
 
     // emails: ストリーミングで NDJSON 出力（OOM 回避）
     zip_writer
@@ -306,6 +362,9 @@ where
         excluded_items_count: excluded_items_rows.len(),
         excluded_orders_count: excluded_orders_rows.len(),
         tracking_check_logs_count: tracking_check_logs_rows.len(),
+        htmls_count: htmls_rows.len(),
+        news_clips_count: news_clips_rows.len(),
+        item_exclusion_patterns_count: item_exclusion_patterns_rows.len(),
         image_files_count,
         images_skipped,
         restore_point_saved: false,
@@ -487,6 +546,51 @@ mod tests {
                 error_message   TEXT,
                 created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 UNIQUE (tracking_number)
+            );",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r"
+            CREATE TABLE IF NOT EXISTS htmls (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                url TEXT UNIQUE NOT NULL,
+                html_content TEXT,
+                analysis_status TEXT NOT NULL DEFAULT 'pending' CHECK(analysis_status IN ('pending', 'completed')),
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r"
+            CREATE TABLE IF NOT EXISTS news_clips (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                url TEXT NOT NULL,
+                source_name TEXT NOT NULL,
+                published_at TEXT,
+                summary TEXT,
+                tags TEXT NOT NULL DEFAULT '[]',
+                clipped_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (url)
+            );",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r"
+            CREATE TABLE IF NOT EXISTS item_exclusion_patterns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                shop_domain TEXT,
+                keyword TEXT NOT NULL,
+                match_type TEXT NOT NULL DEFAULT 'contains' CHECK(match_type IN ('contains', 'starts_with', 'exact')),
+                note TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
             );",
         )
         .execute(&pool)

--- a/src-tauri/src/metadata/import.rs
+++ b/src-tauri/src/metadata/import.rs
@@ -14,9 +14,9 @@ use super::manifest::{
     MAX_EMAILS_NDJSON_ENTRY_SIZE, MAX_IMAGE_ENTRY_SIZE, MAX_NDJSON_LINE_SIZE,
 };
 use super::table_converters::{
-    ImportResult, JsonEmailRow, JsonExcludedItemRow, JsonExcludedOrderRow, JsonImageRow,
-    JsonItemOverrideRow, JsonOrderOverrideRow, JsonProductMasterRow, JsonShopSettingsRow,
-    JsonTrackingCheckLogRow,
+    ImportResult, JsonEmailRow, JsonExcludedItemRow, JsonExcludedOrderRow, JsonHtmlsRow,
+    JsonImageRow, JsonItemExclusionPatternRow, JsonItemOverrideRow, JsonNewsClipRow,
+    JsonOrderOverrideRow, JsonProductMasterRow, JsonShopSettingsRow, JsonTrackingCheckLogRow,
 };
 
 /// ZIP からメタデータをインポート（INSERT OR IGNORE でマージ）
@@ -129,6 +129,32 @@ where
         let json = read_zip_entry(&mut zip_archive, "tracking_check_logs.json")?;
         serde_json::from_str(&json)
             .map_err(|e| format!("Failed to parse tracking_check_logs.json: {e}"))?
+    } else {
+        Vec::new()
+    };
+    let htmls_rows: Vec<JsonHtmlsRow> =
+        if zip_archive.file_names().any(|n| n == "htmls.json") {
+            let json = read_zip_entry(&mut zip_archive, "htmls.json")?;
+            serde_json::from_str(&json)
+                .map_err(|e| format!("Failed to parse htmls.json: {e}"))?
+        } else {
+            Vec::new()
+        };
+    let news_clips_rows: Vec<JsonNewsClipRow> =
+        if zip_archive.file_names().any(|n| n == "news_clips.json") {
+            let json = read_zip_entry(&mut zip_archive, "news_clips.json")?;
+            serde_json::from_str(&json)
+                .map_err(|e| format!("Failed to parse news_clips.json: {e}"))?
+        } else {
+            Vec::new()
+        };
+    let item_exclusion_patterns_rows: Vec<JsonItemExclusionPatternRow> = if zip_archive
+        .file_names()
+        .any(|n| n == "item_exclusion_patterns.json")
+    {
+        let json = read_zip_entry(&mut zip_archive, "item_exclusion_patterns.json")?;
+        serde_json::from_str(&json)
+            .map_err(|e| format!("Failed to parse item_exclusion_patterns.json: {e}"))?
     } else {
         Vec::new()
     };
@@ -447,6 +473,86 @@ where
         }
     }
 
+    let mut htmls_inserted = 0usize;
+    for row in &htmls_rows {
+        let result = sqlx::query(
+            r#"
+            INSERT OR IGNORE INTO htmls (url, html_content, analysis_status)
+            VALUES (?, ?, ?)
+            "#,
+        )
+        .bind(&row.1)
+        .bind(&row.2)
+        .bind(&row.3)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| format!("Failed to insert html: {e}"))?;
+        if result.rows_affected() > 0 {
+            htmls_inserted += 1;
+        }
+    }
+
+    let mut news_clips_inserted = 0usize;
+    for row in &news_clips_rows {
+        let result = sqlx::query(
+            r#"
+            INSERT OR IGNORE INTO news_clips (title, url, source_name, published_at, summary, tags, clipped_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(&row.1)
+        .bind(&row.2)
+        .bind(&row.3)
+        .bind(&row.4)
+        .bind(&row.5)
+        .bind(&row.6)
+        .bind(&row.7)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| format!("Failed to insert news_clip: {e}"))?;
+        if result.rows_affected() > 0 {
+            news_clips_inserted += 1;
+        }
+    }
+
+    // item_exclusion_patterns はスキーマ上 UNIQUE 制約なし。
+    // 既存行と重複しないよう (shop_domain, keyword, match_type) の組み合わせで存在確認してからINSERT。
+    let mut item_exclusion_patterns_inserted = 0usize;
+    for row in &item_exclusion_patterns_rows {
+        let exists: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*) FROM item_exclusion_patterns
+            WHERE (shop_domain IS ? OR (shop_domain IS NULL AND ? IS NULL))
+              AND keyword = ?
+              AND match_type = ?
+            "#,
+        )
+        .bind(&row.1)
+        .bind(&row.1)
+        .bind(&row.2)
+        .bind(&row.3)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| format!("Failed to check item_exclusion_pattern: {e}"))?;
+        if exists.0 == 0 {
+            sqlx::query(
+                r#"
+                INSERT INTO item_exclusion_patterns (shop_domain, keyword, match_type, note, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                "#,
+            )
+            .bind(&row.1)
+            .bind(&row.2)
+            .bind(&row.3)
+            .bind(&row.4)
+            .bind(&row.5)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| format!("Failed to insert item_exclusion_pattern: {e}"))?;
+            item_exclusion_patterns_inserted += 1;
+        }
+    }
+
     tx.commit()
         .await
         .map_err(|e| format!("Failed to commit transaction: {e}"))?;
@@ -509,6 +615,9 @@ where
         excluded_items_inserted,
         excluded_orders_inserted,
         tracking_check_logs_inserted,
+        htmls_inserted,
+        news_clips_inserted,
+        item_exclusion_patterns_inserted,
         image_files_copied,
         restore_point_updated: None,
         restore_point_path: None,
@@ -687,6 +796,51 @@ mod tests {
                 error_message   TEXT,
                 created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 UNIQUE (tracking_number)
+            );",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r"
+            CREATE TABLE IF NOT EXISTS htmls (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                url TEXT UNIQUE NOT NULL,
+                html_content TEXT,
+                analysis_status TEXT NOT NULL DEFAULT 'pending' CHECK(analysis_status IN ('pending', 'completed')),
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r"
+            CREATE TABLE IF NOT EXISTS news_clips (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                url TEXT NOT NULL,
+                source_name TEXT NOT NULL,
+                published_at TEXT,
+                summary TEXT,
+                tags TEXT NOT NULL DEFAULT '[]',
+                clipped_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (url)
+            );",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            r"
+            CREATE TABLE IF NOT EXISTS item_exclusion_patterns (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                shop_domain TEXT,
+                keyword TEXT NOT NULL,
+                match_type TEXT NOT NULL DEFAULT 'contains' CHECK(match_type IN ('contains', 'starts_with', 'exact')),
+                note TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
             );",
         )
         .execute(&pool)

--- a/src-tauri/src/metadata/import.rs
+++ b/src-tauri/src/metadata/import.rs
@@ -132,14 +132,12 @@ where
     } else {
         Vec::new()
     };
-    let htmls_rows: Vec<JsonHtmlsRow> =
-        if zip_archive.file_names().any(|n| n == "htmls.json") {
-            let json = read_zip_entry(&mut zip_archive, "htmls.json")?;
-            serde_json::from_str(&json)
-                .map_err(|e| format!("Failed to parse htmls.json: {e}"))?
-        } else {
-            Vec::new()
-        };
+    let htmls_rows: Vec<JsonHtmlsRow> = if zip_archive.file_names().any(|n| n == "htmls.json") {
+        let json = read_zip_entry(&mut zip_archive, "htmls.json")?;
+        serde_json::from_str(&json).map_err(|e| format!("Failed to parse htmls.json: {e}"))?
+    } else {
+        Vec::new()
+    };
     let news_clips_rows: Vec<JsonNewsClipRow> =
         if zip_archive.file_names().any(|n| n == "news_clips.json") {
             let json = read_zip_entry(&mut zip_archive, "news_clips.json")?;

--- a/src-tauri/src/metadata/table_converters.rs
+++ b/src-tauri/src/metadata/table_converters.rs
@@ -103,6 +103,32 @@ pub(super) type TrackingCheckLogRow = (
     String,
 );
 
+/// htmls テーブル行 (id, url, html_content, analysis_status, created_at, updated_at)
+pub(super) type HtmlsRow = (
+    i64,
+    String,
+    Option<String>,
+    String,
+    Option<String>,
+    Option<String>,
+);
+
+/// news_clips テーブル行 (id, title, url, source_name, published_at, summary, tags, clipped_at)
+pub(super) type NewsClipRow = (
+    i64,
+    String,
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    String,
+    String,
+);
+
+/// item_exclusion_patterns テーブル行 (id, shop_domain, keyword, match_type, note, created_at)
+pub(super) type ItemExclusionPatternRow =
+    (i64, Option<String>, String, String, Option<String>, String);
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ExportResult {
     pub images_count: usize,
@@ -114,6 +140,9 @@ pub struct ExportResult {
     pub excluded_items_count: usize,
     pub excluded_orders_count: usize,
     pub tracking_check_logs_count: usize,
+    pub htmls_count: usize,
+    pub news_clips_count: usize,
+    pub item_exclusion_patterns_count: usize,
     pub image_files_count: usize,
     /// スキップした画像数（不正な file_name、サイズ超過、ファイル不存在）
     pub images_skipped: usize,
@@ -136,6 +165,9 @@ pub struct ImportResult {
     pub excluded_items_inserted: usize,
     pub excluded_orders_inserted: usize,
     pub tracking_check_logs_inserted: usize,
+    pub htmls_inserted: usize,
+    pub news_clips_inserted: usize,
+    pub item_exclusion_patterns_inserted: usize,
     pub image_files_copied: usize,
     /// app_data_dir 直下の復元ポイントZIPを更新できたか（インポート時）
     /// Some(true): 更新成功, Some(false): 更新失敗, None: 更新不要（restore_metadata）
@@ -264,4 +296,39 @@ pub(super) struct JsonTrackingCheckLogRow(
     pub(super) Option<String>, // location
     pub(super) Option<String>, // error_message
     pub(super) Option<String>, // created_at (インポート時に COALESCE(?, CURRENT_TIMESTAMP) で使用)
+);
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+pub(super) struct JsonHtmlsRow(
+    pub(super) i64,            // id (未使用)
+    pub(super) String,         // url
+    pub(super) Option<String>, // html_content
+    pub(super) String,         // analysis_status
+    pub(super) Option<String>, // created_at (未使用)
+    pub(super) Option<String>, // updated_at (未使用)
+);
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+pub(super) struct JsonNewsClipRow(
+    pub(super) i64,            // id (未使用)
+    pub(super) String,         // title
+    pub(super) String,         // url
+    pub(super) String,         // source_name
+    pub(super) Option<String>, // published_at
+    pub(super) Option<String>, // summary
+    pub(super) String,         // tags
+    pub(super) String,         // clipped_at
+);
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+pub(super) struct JsonItemExclusionPatternRow(
+    pub(super) i64,            // id (未使用)
+    pub(super) Option<String>, // shop_domain
+    pub(super) String,         // keyword
+    pub(super) String,         // match_type
+    pub(super) Option<String>, // note
+    pub(super) String,         // created_at
 );

--- a/src/components/screens/backup.test.tsx
+++ b/src/components/screens/backup.test.tsx
@@ -81,6 +81,9 @@ describe('Backup', () => {
         excluded_items_count: 1,
         excluded_orders_count: 2,
         tracking_check_logs_count: 7,
+        htmls_count: 4,
+        news_clips_count: 6,
+        item_exclusion_patterns_count: 3,
         image_files_count: 45,
         images_skipped: 0,
       });
@@ -104,7 +107,7 @@ describe('Backup', () => {
       await waitFor(() => {
         expect(
           screen.getByText(
-            /バックアップを保存しました（合計: 110件、画像ファイル: 45件）/
+            /バックアップを保存しました（合計: 123件、画像ファイル: 45件）/
           )
         ).toBeInTheDocument();
       });
@@ -158,6 +161,9 @@ describe('Backup', () => {
         excluded_items_count: 1,
         excluded_orders_count: 2,
         tracking_check_logs_count: 7,
+        htmls_count: 4,
+        news_clips_count: 6,
+        item_exclusion_patterns_count: 3,
         image_files_count: 45,
         images_skipped: 0,
         restore_point_saved: false,
@@ -173,7 +179,7 @@ describe('Backup', () => {
       await waitFor(() => {
         expect(
           screen.getByText(
-            /バックアップを保存しました（合計: 110件、画像ファイル: 45件）/
+            /バックアップを保存しました（合計: 123件、画像ファイル: 45件）/
           )
         ).toBeInTheDocument();
       });
@@ -239,6 +245,9 @@ describe('Backup', () => {
         excluded_items_inserted: 1,
         excluded_orders_inserted: 1,
         tracking_check_logs_inserted: 3,
+        htmls_inserted: 2,
+        news_clips_inserted: 5,
+        item_exclusion_patterns_inserted: 1,
         image_files_copied: 38,
       });
 
@@ -265,7 +274,7 @@ describe('Backup', () => {
       await waitFor(() => {
         expect(
           screen.getByText(
-            /インポートしました（合計: 85件、画像ファイル: 38件）/
+            /インポートしました（合計: 93件、画像ファイル: 38件）/
           )
         ).toBeInTheDocument();
       });
@@ -326,6 +335,9 @@ describe('Backup', () => {
         excluded_items_inserted: 1,
         excluded_orders_inserted: 1,
         tracking_check_logs_inserted: 3,
+        htmls_inserted: 2,
+        news_clips_inserted: 5,
+        item_exclusion_patterns_inserted: 1,
         image_files_copied: 38,
         restore_point_updated: false,
         restore_point_error: 'ファイルシステムエラー',
@@ -340,7 +352,7 @@ describe('Backup', () => {
       await waitFor(() => {
         expect(
           screen.getByText(
-            /インポートしました（合計: 85件、画像ファイル: 38件）/
+            /インポートしました（合計: 93件、画像ファイル: 38件）/
           )
         ).toBeInTheDocument();
       });
@@ -388,6 +400,9 @@ describe('Backup', () => {
         excluded_items_inserted: 1,
         excluded_orders_inserted: 1,
         tracking_check_logs_inserted: 3,
+        htmls_inserted: 2,
+        news_clips_inserted: 5,
+        item_exclusion_patterns_inserted: 1,
         image_files_copied: 38,
         restore_point_updated: false,
         restore_point_error: 'ディスク容量不足',
@@ -402,7 +417,7 @@ describe('Backup', () => {
       await waitFor(() => {
         expect(
           screen.getByText(
-            /インポートしました（合計: 85件、画像ファイル: 38件）/
+            /インポートしました（合計: 93件、画像ファイル: 38件）/
           )
         ).toBeInTheDocument();
       });

--- a/src/components/screens/backup.tsx
+++ b/src/components/screens/backup.tsx
@@ -28,6 +28,9 @@ interface ExportResult {
   excluded_items_count: number;
   excluded_orders_count: number;
   tracking_check_logs_count: number;
+  htmls_count: number;
+  news_clips_count: number;
+  item_exclusion_patterns_count: number;
   image_files_count: number;
   images_skipped: number;
   restore_point_saved?: boolean;
@@ -45,6 +48,9 @@ interface ImportResult {
   excluded_items_inserted: number;
   excluded_orders_inserted: number;
   tracking_check_logs_inserted: number;
+  htmls_inserted: number;
+  news_clips_inserted: number;
+  item_exclusion_patterns_inserted: number;
   image_files_copied: number;
   restore_point_updated?: boolean | null;
   restore_point_path?: string | null;
@@ -109,6 +115,9 @@ export function Backup() {
         ['excluded_items', result.excluded_items_count],
         ['excluded_orders', result.excluded_orders_count],
         ['tracking_check_logs', result.tracking_check_logs_count],
+        ['htmls', result.htmls_count],
+        ['news_clips', result.news_clips_count],
+        ['item_exclusion_patterns', result.item_exclusion_patterns_count],
       ]);
       toastSuccess(
         `バックアップを保存しました（合計: ${total}件、画像ファイル: ${result.image_files_count}件）`,
@@ -168,6 +177,9 @@ export function Backup() {
         ['excluded_items', result.excluded_items_inserted],
         ['excluded_orders', result.excluded_orders_inserted],
         ['tracking_check_logs', result.tracking_check_logs_inserted],
+        ['htmls', result.htmls_inserted],
+        ['news_clips', result.news_clips_inserted],
+        ['item_exclusion_patterns', result.item_exclusion_patterns_inserted],
       ]);
       toastSuccess(
         `インポートしました（合計: ${total}件、画像ファイル: ${result.image_files_copied}件）`,
@@ -212,6 +224,9 @@ export function Backup() {
         ['excluded_items', result.excluded_items_inserted],
         ['excluded_orders', result.excluded_orders_inserted],
         ['tracking_check_logs', result.tracking_check_logs_inserted],
+        ['htmls', result.htmls_inserted],
+        ['news_clips', result.news_clips_inserted],
+        ['item_exclusion_patterns', result.item_exclusion_patterns_inserted],
       ]);
       toastSuccess(
         `復元しました（復元ポイント）（合計: ${total}件、画像ファイル: ${result.image_files_copied}件）`,


### PR DESCRIPTION
## Summary

- `htmls`（追跡確認用HTMLキャッシュ）、`news_clips`（ユーザー保存記事）、`item_exclusion_patterns`（除外キーワード設定）の3テーブルをバックアップ対象に追加
- これらはメール再パースでは復元できないユーザーデータのため、バックアップ必須と判断
- `item_exclusion_patterns` はスキーマに UNIQUE 制約がないため、`(shop_domain, keyword, match_type)` の組み合わせで存在確認してから INSERT（重複防止）
- 旧バックアップZIPとの後方互換性を維持（3ファイルが含まれない場合はスキップ）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src-tauri/src/metadata/table_converters.rs` | 3テーブルの行型・JsonRow構造体・ExportResult/ImportResultにフィールド追加 |
| `src-tauri/src/metadata/export.rs` | 3テーブルのクエリ・ZIPエントリ追加、テスト用DBにテーブル追加 |
| `src-tauri/src/metadata/import.rs` | ZIPから3テーブルを読み込みINSERTする処理追加、テスト用DBにテーブル追加 |
| `src/components/screens/backup.tsx` | ExportResult/ImportResultインターフェースと表示件数に3テーブルを追加 |

## Test plan

- [ ] 全Rustテスト通過確認（`cargo test` — 1196 passed）
- [ ] エクスポートしたZIPに `htmls.json` / `news_clips.json` / `item_exclusion_patterns.json` が含まれること
- [ ] インポート・復元で3テーブルのデータが正しく復元されること
- [ ] 旧バックアップZIP（3ファイルなし）のインポートがエラーにならないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)