### PR TITLE
feat: データ＞テーブルに news_clips / item_exclusion_patterns を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,8 @@ import {
   ExcludedItemsTable,
   ExcludedOrdersTable,
   TrackingCheckLogsTable,
+  NewsClipsTable,
+  ItemExclusionPatternsTable,
 } from '@/components/screens/tables';
 import { TitleBar } from '@/components/layout/titlebar';
 import { NavigationProvider } from '@/contexts/navigation-provider';
@@ -131,6 +133,10 @@ function AppContent() {
         return <ExcludedOrdersTable />;
       case 'table-tracking-check-logs':
         return <TrackingCheckLogsTable />;
+      case 'table-news-clips':
+        return <NewsClipsTable />;
+      case 'table-item-exclusion-patterns':
+        return <ItemExclusionPatternsTable />;
       default:
         return <Orders />;
     }

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -62,6 +62,8 @@ type TableScreen = Extract<
   | 'table-excluded-items'
   | 'table-excluded-orders'
   | 'table-tracking-check-logs'
+  | 'table-news-clips'
+  | 'table-item-exclusion-patterns'
 >;
 
 type TableItem = {
@@ -99,6 +101,8 @@ const tableItems: TableItem[] = [
   { name: '除外アイテム', id: 'table-excluded-items' },
   { name: '除外注文', id: 'table-excluded-orders' },
   { name: '配送確認ログ', id: 'table-tracking-check-logs' },
+  { name: 'ニュースクリップ', id: 'table-news-clips' },
+  { name: '除外キーワードパターン', id: 'table-item-exclusion-patterns' },
 ];
 
 export function Sidebar() {

--- a/src/components/screens/tables.tsx
+++ b/src/components/screens/tables.tsx
@@ -65,3 +65,18 @@ export function TrackingCheckLogsTable() {
     <TableViewer tableName="tracking_check_logs" title="配送確認ログテーブル" />
   );
 }
+
+export function NewsClipsTable() {
+  return (
+    <TableViewer tableName="news_clips" title="ニュースクリップテーブル" />
+  );
+}
+
+export function ItemExclusionPatternsTable() {
+  return (
+    <TableViewer
+      tableName="item_exclusion_patterns"
+      title="除外キーワードパターンテーブル"
+    />
+  );
+}

--- a/src/components/tables/table-viewer.tsx
+++ b/src/components/tables/table-viewer.tsx
@@ -179,6 +179,35 @@ const COLUMN_LABELS: Record<string, Record<string, string>> = {
     reason: '除外理由',
     created_at: '作成日時',
   },
+  tracking_check_logs: {
+    id: 'ID',
+    tracking_number: '追跡番号',
+    checked_at: '確認日時',
+    check_status: 'チェック結果',
+    delivery_status: '配送ステータス',
+    description: '説明',
+    location: '場所',
+    error_message: 'エラーメッセージ',
+    created_at: '作成日時',
+  },
+  news_clips: {
+    id: 'ID',
+    title: 'タイトル',
+    url: 'URL',
+    source_name: '情報源',
+    published_at: '公開日時',
+    summary: '要約',
+    tags: 'タグ',
+    clipped_at: 'クリップ日時',
+  },
+  item_exclusion_patterns: {
+    id: 'ID',
+    shop_domain: 'ショップドメイン',
+    keyword: 'キーワード',
+    match_type: 'マッチ種別',
+    note: 'メモ',
+    created_at: '作成日時',
+  },
 };
 
 function getColumnLabel(tableName: string, column: string): string {

--- a/src/contexts/navigation-context-value.ts
+++ b/src/contexts/navigation-context-value.ts
@@ -26,7 +26,9 @@ export type Screen =
   | 'table-order-overrides'
   | 'table-excluded-items'
   | 'table-excluded-orders'
-  | 'table-tracking-check-logs';
+  | 'table-tracking-check-logs'
+  | 'table-news-clips'
+  | 'table-item-exclusion-patterns';
 
 export type NavigationContextType = {
   currentScreen: Screen;

--- a/src/contexts/navigation-context.test.tsx
+++ b/src/contexts/navigation-context.test.tsx
@@ -53,6 +53,8 @@ describe('NavigationContext', () => {
       'table-excluded-items',
       'table-excluded-orders',
       'table-tracking-check-logs',
+      'table-news-clips',
+      'table-item-exclusion-patterns',
     ] as const;
 
     tableScreens.forEach((screen) => {

--- a/src/lib/table-utils.test.ts
+++ b/src/lib/table-utils.test.ts
@@ -23,6 +23,8 @@ describe('table-utils', () => {
       expect(VALID_TABLES).toContain('excluded_items');
       expect(VALID_TABLES).toContain('excluded_orders');
       expect(VALID_TABLES).toContain('tracking_check_logs');
+      expect(VALID_TABLES).toContain('news_clips');
+      expect(VALID_TABLES).toContain('item_exclusion_patterns');
     });
   });
 

--- a/src/lib/table-utils.ts
+++ b/src/lib/table-utils.ts
@@ -21,6 +21,8 @@ export const VALID_TABLES = [
   'excluded_items',
   'excluded_orders',
   'tracking_check_logs',
+  'news_clips',
+  'item_exclusion_patterns',
 ] as const;
 
 export type ValidTableName = (typeof VALID_TABLES)[number];


### PR DESCRIPTION
## Summary

- マイグレーション `002_news_clips.sql` で追加された `news_clips` テーブルをサイドバーとテーブルビューアーに追加
- マイグレーション `003_item_exclusion_patterns.sql` で追加された `item_exclusion_patterns` テーブルを同様に追加
- `COLUMN_LABELS` に未登録だった `tracking_check_logs` の日本語ラベルを追加

## Changes

| ファイル | 変更内容 |
|---|---|
| `src/lib/table-utils.ts` | `VALID_TABLES` に2テーブルを追加 |
| `src/contexts/navigation-context-value.ts` | `Screen` 型に2画面IDを追加 |
| `src/components/layout/sidebar.tsx` | `TableScreen` 型と `tableItems` に2テーブルを追加 |
| `src/components/screens/tables.tsx` | `NewsClipsTable`・`ItemExclusionPatternsTable` を追加 |
| `src/App.tsx` | import と `case` 分岐を追加 |
| `src/components/tables/table-viewer.tsx` | `COLUMN_LABELS` に3テーブル分の日本語ラベルを追加 |
| `src/lib/table-utils.test.ts` | 2テーブルの検証を追加 |
| `src/contexts/navigation-context.test.tsx` | 画面リストに2テーブルを追加 |

## Test plan

- [ ] サイドバーの「データ」セクションに「ニュースクリップ」「除外キーワードパターン」が表示される
- [ ] 各テーブルをクリックするとデータが正しく表示される
- [ ] カラム名が日本語で表示される
- [ ] `pnpm test` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)