### PR TITLE
feat: ニュースクリップタブにカレンダービューとAIイベント抽出を追加

### DIFF
--- a/src-tauri/migrations/004_news_clip_events.sql
+++ b/src-tauri/migrations/004_news_clip_events.sql
@@ -1,0 +1,3 @@
+-- news_clips テーブルに AI 抽出イベント日付カラムを追加
+-- events: JSON 配列 [{"date":"YYYY-MM-DD","label":"イベント説明"}, ...]
+ALTER TABLE news_clips ADD COLUMN events TEXT NOT NULL DEFAULT '[]';

--- a/src-tauri/src/commands/news.rs
+++ b/src-tauri/src/commands/news.rs
@@ -1,3 +1,4 @@
+use chrono::Datelike;
 use reqwest;
 use scraper::{Html, Selector};
 use serde::{Deserialize, Serialize};
@@ -383,6 +384,47 @@ pub async fn fetch_news_html(
 // クリップ機能
 // =============================================================================
 
+/// AI が抽出したイベント日付
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NewsClipEvent {
+    pub date: String,  // YYYY-MM-DD
+    pub label: String,
+}
+
+/// Gemini レスポンスのパース用（null 許容）
+#[derive(Debug, Deserialize)]
+struct RawClipEvent {
+    date: Option<String>,
+    label: Option<String>,
+}
+
+impl RawClipEvent {
+    fn into_event(self) -> Option<NewsClipEvent> {
+        let date = self.date.filter(|s| is_valid_date_key(s))?;
+        let label = self.label.filter(|s| !s.is_empty())?;
+        Some(NewsClipEvent { date, label })
+    }
+}
+
+/// YYYY-MM-DD 形式かつ実在する日付かを検証する
+fn is_valid_date_key(s: &str) -> bool {
+    // 長さと基本フォーマットチェック
+    if s.len() != 10 { return false; }
+    let parts: Vec<&str> = s.splitn(3, '-').collect();
+    if parts.len() != 3 { return false; }
+    let (Ok(y), Ok(m), Ok(d)) = (
+        parts[0].parse::<i32>(),
+        parts[1].parse::<u32>(),
+        parts[2].parse::<u32>(),
+    ) else { return false; };
+    // 年は 2000〜2100、月は 1〜12、日は 1〜31 の範囲チェック（簡易）
+    if !(2000..=2100).contains(&y) || !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return false;
+    }
+    // chrono で実在日付かチェック
+    chrono::NaiveDate::from_ymd_opt(y, m, d).is_some()
+}
+
 #[derive(Debug, Serialize)]
 pub struct NewsClip {
     pub id: i64,
@@ -393,6 +435,7 @@ pub struct NewsClip {
     pub summary: Option<String>,
     pub tags: Vec<String>,
     pub clipped_at: String,
+    pub events: Vec<NewsClipEvent>,
 }
 
 /// DB の生行をドメイン型に変換するヘルパー
@@ -406,6 +449,7 @@ type ClipRow = (
     Option<String>,
     String,
     String,
+    String, // events (JSON)
 );
 
 fn row_to_clip(row: ClipRow) -> NewsClip {
@@ -419,6 +463,7 @@ fn row_to_clip(row: ClipRow) -> NewsClip {
         summary: row.5,
         tags,
         clipped_at: row.7,
+        events: serde_json::from_str(&row.8).unwrap_or_default(),
     }
 }
 
@@ -485,16 +530,19 @@ async fn fetch_article_content(url: &str) -> Option<String> {
 struct GeminiSummaryResult {
     summary: String,
     tags: Vec<String>,
+    #[serde(default)]
+    events: Vec<RawClipEvent>,
 }
 
-/// Gemini API を呼び出して記事の要約とタグを生成する
+/// Gemini API を呼び出して記事の要約・タグ・イベント日付を生成する
 async fn summarize_with_gemini(
     api_key: &str,
     title: &str,
     content: &str,
-) -> Result<(String, Vec<String>), String> {
+) -> Result<(String, Vec<String>, Vec<NewsClipEvent>), String> {
     let prompt = format!(
-        "以下のゲーム・ホビー系ニュース記事を分析してください。\n\nタイトル: {title}\n\n本文:\n{content}\n\n次のJSON形式のみで回答してください（余分なテキスト不要）:\n{{\"summary\":\"記事の要約（100〜150文字）\",\"tags\":[\"タグ1\",\"タグ2\",\"タグ3\",\"タグ4\",\"タグ5\"]}}\n\nsummaryは日本語で簡潔に。tagsはゲームタイトル・シリーズ・ジャンル・ハード名・会社名などを5個程度。"
+        "以下のゲーム・ホビー系ニュース記事を分析してください。\n\n【本日の日付】{today}\n\nタイトル: {title}\n\n本文:\n{content}\n\n次のJSON形式のみで回答してください（余分なテキスト不要）:\n{{\"summary\":\"記事の要約（100〜150文字）\",\"tags\":[\"タグ1\",\"タグ2\",\"タグ3\",\"タグ4\",\"タグ5\"],\"events\":[{{\"date\":\"YYYY-MM-DD\",\"label\":\"イベントの説明\"}}]}}\n\nsummaryは日本語で簡潔に。tagsはゲームタイトル・シリーズ・ジャンル・ハード名・会社名など5個程度。eventsは記事内の具体的な日程（発売日・予約開始日・配信開始日など）をYYYY-MM-DD形式で。年が明示されていない場合は【本日の日付】を基準に補完すること。labelはゲームタイトル等の主語を含む簡潔な説明（例：「Nintendo Switch 2予約開始」「ドラゴンクエスト3発売」）。【重要】dateはYYYY-MM-DD形式の完全な日付のみ（年・月・日すべて必須）。不完全または不明な場合はそのイベントを含めないこと。日程情報がなければeventsは空配列。",
+        today = chrono::Utc::now().format("%Y-%m-%d")
     );
 
     let body = serde_json::json!({
@@ -544,7 +592,111 @@ async fn summarize_with_gemini(
     let result: GeminiSummaryResult =
         serde_json::from_str(text).map_err(|e| format!("AIレスポンスのJSONパースに失敗: {e}"))?;
 
-    Ok((result.summary, result.tags))
+    let raw_count = result.events.len();
+    let events: Vec<NewsClipEvent> = result
+        .events
+        .into_iter()
+        .filter_map(RawClipEvent::into_event)
+        .collect();
+
+    log::info!(
+        "[clip_events/summarize] title={:?} raw={} → valid={}",
+        title.chars().take(50).collect::<String>(),
+        raw_count,
+        events.len()
+    );
+    for ev in &events {
+        log::info!("[clip_events/summarize]   date={} label={:?}", ev.date, ev.label);
+    }
+
+    Ok((result.summary, result.tags, events))
+}
+
+// -------------------------------------------------------
+// 要約テキストからイベント日付のみを抽出（既存クリップの backfill 用）
+// -------------------------------------------------------
+
+/// 要約・タイトルをもとに Gemini でイベント日付のみ抽出する
+async fn extract_events_with_gemini(
+    api_key: &str,
+    title: &str,
+    summary: &str,
+) -> Result<Vec<NewsClipEvent>, String> {
+    let prompt = format!(
+        "以下のゲーム・ホビー系ニュース記事のタイトルと要約から、具体的な日程情報を抽出してください。\n\n【本日の日付】{today}\n\nタイトル: {title}\n要約: {summary}\n\n次のJSON配列形式のみで回答してください（余分なテキスト不要）:\n[{{\"date\":\"YYYY-MM-DD\",\"label\":\"イベントの説明\"}}]\n\n【重要ルール】\n- dateは必ずYYYY-MM-DD形式の完全な日付（年・月・日すべて必須）\n- 年が明示されていない場合は【本日の日付】の年を基準に最も近い将来の日付として補完すること\n- dateがnullや年月日が不完全な場合はそのイベントを配列に含めないこと\n- labelはゲームタイトル等の主語を含む簡潔な説明（例：「Nintendo Switch 2予約開始」「ドラゴンクエスト3発売」）\n- 具体的な日付が見当たらない場合は空配列 [] を返してください",
+        today = chrono::Utc::now().format("%Y-%m-%d")
+    );
+
+    let body = serde_json::json!({
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {
+            "responseMimeType": "application/json",
+            "temperature": 0.1,
+            "maxOutputTokens": 512
+        }
+    })
+    .to_string();
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(GEMINI_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| format!("HTTPクライアントの初期化に失敗: {e}"))?;
+
+    let response = client
+        .post("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent")
+        .header("Content-Type", "application/json")
+        .header("X-goog-api-key", api_key)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| format!("Gemini APIへの接続に失敗しました: {e}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        return Err(format!("Gemini API エラー (status {status})"));
+    }
+
+    let response_text = response
+        .text()
+        .await
+        .map_err(|e| format!("Gemini レスポンスの読み取りに失敗: {e}"))?;
+
+    let gemini_resp: serde_json::Value = serde_json::from_str(&response_text)
+        .map_err(|e| format!("Gemini レスポンスのパースに失敗: {e}"))?;
+
+    let text = gemini_resp["candidates"][0]["content"]["parts"][0]["text"]
+        .as_str()
+        .ok_or_else(|| "Gemini レスポンスからテキストを取得できませんでした".to_string())?;
+
+    log::info!("[clip_events/backfill] gemini raw text: {text}");
+
+    let raw: Vec<RawClipEvent> =
+        serde_json::from_str(text).map_err(|e| format!("AIレスポンスのJSONパースに失敗: {e}"))?;
+
+    let raw_count = raw.len();
+    let mut events = Vec::new();
+    for r in raw {
+        let date_str = r.date.clone().unwrap_or_else(|| "(null)".to_string());
+        let label_str = r.label.clone().unwrap_or_else(|| "(null)".to_string());
+        match r.into_event() {
+            Some(ev) => {
+                log::info!("[clip_events/backfill]   OK   date={} label={:?}", ev.date, ev.label);
+                events.push(ev);
+            }
+            None => {
+                log::info!("[clip_events/backfill]   DROP date={date_str:?} label={label_str:?}");
+            }
+        }
+    }
+
+    log::info!(
+        "[clip_events/backfill] title={:?} raw={} → valid={}",
+        title.chars().take(50).collect::<String>(),
+        raw_count,
+        events.len()
+    );
+
+    Ok(events)
 }
 
 // -------------------------------------------------------
@@ -575,27 +727,21 @@ pub async fn clip_news_article(
         .or(description)
         .unwrap_or_else(|| title.clone());
 
-    let (summary, tags) = summarize_with_gemini(&api_key, &title, &content).await?;
+    let (summary, tags, events) = summarize_with_gemini(&api_key, &title, &content).await?;
 
     let tags_json =
         serde_json::to_string(&tags).map_err(|e| format!("タグのシリアライズに失敗: {e}"))?;
+    let events_json =
+        serde_json::to_string(&events).map_err(|e| format!("イベントのシリアライズに失敗: {e}"))?;
 
-    let row: (
-        i64,
-        String,
-        String,
-        String,
-        Option<String>,
-        Option<String>,
-        String,
-        String,
-    ) = sqlx::query_as(
-        "INSERT INTO news_clips (title, url, source_name, published_at, summary, tags)
-             VALUES (?, ?, ?, ?, ?, ?)
+    let row: ClipRow = sqlx::query_as(
+        "INSERT INTO news_clips (title, url, source_name, published_at, summary, tags, events)
+             VALUES (?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(url) DO UPDATE SET
                summary = excluded.summary,
-               tags    = excluded.tags
-             RETURNING id, title, url, source_name, published_at, summary, tags, clipped_at",
+               tags    = excluded.tags,
+               events  = excluded.events
+             RETURNING id, title, url, source_name, published_at, summary, tags, clipped_at, events",
     )
     .bind(&title)
     .bind(&url)
@@ -603,6 +749,7 @@ pub async fn clip_news_article(
     .bind(&published_at)
     .bind(&summary)
     .bind(&tags_json)
+    .bind(&events_json)
     .fetch_one(pool.inner())
     .await
     .map_err(|e| format!("クリップの保存に失敗しました: {e}"))?;
@@ -610,11 +757,59 @@ pub async fn clip_news_article(
     Ok(row_to_clip(row))
 }
 
+/// 既存クリップのイベント日付を AI で再抽出して更新する（backfill 用）
+#[tauri::command]
+pub async fn refresh_clip_events(
+    pool: tauri::State<'_, SqlitePool>,
+    app_handle: tauri::AppHandle,
+    clip_id: i64,
+) -> Result<NewsClip, String> {
+    // クリップ取得
+    let row: ClipRow = sqlx::query_as(
+        "SELECT id, title, url, source_name, published_at, summary, tags, clipped_at, events
+             FROM news_clips WHERE id = ?",
+    )
+    .bind(clip_id)
+    .fetch_one(pool.inner())
+    .await
+    .map_err(|e| format!("クリップの取得に失敗しました: {e}"))?;
+
+    let clip = row_to_clip(row);
+
+    let summary = match &clip.summary {
+        Some(s) if !s.is_empty() => s.clone(),
+        _ => return Err("要約が存在しないためイベントを抽出できません".to_string()),
+    };
+
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("アプリデータディレクトリの取得に失敗: {e}"))?;
+
+    let api_key = crate::gemini::config::load_api_key(&app_data_dir)?;
+    let events = extract_events_with_gemini(&api_key, &clip.title, &summary).await?;
+
+    let events_json =
+        serde_json::to_string(&events).map_err(|e| format!("イベントのシリアライズに失敗: {e}"))?;
+
+    let updated_row: ClipRow = sqlx::query_as(
+        "UPDATE news_clips SET events = ? WHERE id = ?
+             RETURNING id, title, url, source_name, published_at, summary, tags, clipped_at, events",
+    )
+    .bind(&events_json)
+    .bind(clip_id)
+    .fetch_one(pool.inner())
+    .await
+    .map_err(|e| format!("クリップの更新に失敗しました: {e}"))?;
+
+    Ok(row_to_clip(updated_row))
+}
+
 /// クリップ一覧を clipped_at 降順で返す
 #[tauri::command]
 pub async fn get_news_clips(pool: tauri::State<'_, SqlitePool>) -> Result<Vec<NewsClip>, String> {
     let rows: Vec<ClipRow> = sqlx::query_as(
-        "SELECT id, title, url, source_name, published_at, summary, tags, clipped_at
+        "SELECT id, title, url, source_name, published_at, summary, tags, clipped_at, events
              FROM news_clips
              ORDER BY clipped_at DESC",
     )

--- a/src-tauri/src/commands/news.rs
+++ b/src-tauri/src/commands/news.rs
@@ -386,7 +386,7 @@ pub async fn fetch_news_html(
 /// AI が抽出したイベント日付
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NewsClipEvent {
-    pub date: String,  // YYYY-MM-DD
+    pub date: String, // YYYY-MM-DD
     pub label: String,
 }
 
@@ -408,14 +408,20 @@ impl RawClipEvent {
 /// YYYY-MM-DD 形式かつ実在する日付かを検証する
 fn is_valid_date_key(s: &str) -> bool {
     // 長さと基本フォーマットチェック
-    if s.len() != 10 { return false; }
+    if s.len() != 10 {
+        return false;
+    }
     let parts: Vec<&str> = s.splitn(3, '-').collect();
-    if parts.len() != 3 { return false; }
+    if parts.len() != 3 {
+        return false;
+    }
     let (Ok(y), Ok(m), Ok(d)) = (
         parts[0].parse::<i32>(),
         parts[1].parse::<u32>(),
         parts[2].parse::<u32>(),
-    ) else { return false; };
+    ) else {
+        return false;
+    };
     // 年は 2000〜2100、月は 1〜12、日は 1〜31 の範囲チェック（簡易）
     if !(2000..=2100).contains(&y) || !(1..=12).contains(&m) || !(1..=31).contains(&d) {
         return false;
@@ -605,7 +611,11 @@ async fn summarize_with_gemini(
         events.len()
     );
     for ev in &events {
-        log::info!("[clip_events/summarize]   date={} label={:?}", ev.date, ev.label);
+        log::info!(
+            "[clip_events/summarize]   date={} label={:?}",
+            ev.date,
+            ev.label
+        );
     }
 
     Ok((result.summary, result.tags, events))
@@ -679,7 +689,11 @@ async fn extract_events_with_gemini(
         let label_str = r.label.clone().unwrap_or_else(|| "(null)".to_string());
         match r.into_event() {
             Some(ev) => {
-                log::info!("[clip_events/backfill]   OK   date={} label={:?}", ev.date, ev.label);
+                log::info!(
+                    "[clip_events/backfill]   OK   date={} label={:?}",
+                    ev.date,
+                    ev.label
+                );
                 events.push(ev);
             }
             None => {

--- a/src-tauri/src/commands/news.rs
+++ b/src-tauri/src/commands/news.rs
@@ -1,4 +1,3 @@
-use chrono::Datelike;
 use reqwest;
 use scraper::{Html, Selector};
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,6 +64,12 @@ pub fn run() {
                 sql: include_str!("../migrations/003_item_exclusion_patterns.sql"),
                 kind: MigrationKind::Up,
             },
+            Migration {
+                version: 4,
+                description: "news_clip_events",
+                sql: include_str!("../migrations/004_news_clip_events.sql"),
+                kind: MigrationKind::Up,
+            },
         ]
     };
 
@@ -735,6 +741,7 @@ pub fn run() {
             commands::get_news_clips,
             commands::delete_news_clip,
             commands::get_clipped_urls,
+            commands::refresh_clip_events,
             commands::list_exclusion_patterns,
             commands::add_exclusion_pattern,
             commands::delete_exclusion_pattern,

--- a/src/components/news/news-clip-calendar.tsx
+++ b/src/components/news/news-clip-calendar.tsx
@@ -1,0 +1,282 @@
+import { useState, useMemo } from 'react';
+import { ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react';
+import type { NewsClip } from '@/lib/news/clips';
+import { cn } from '@/lib/utils';
+
+interface NewsClipCalendarProps {
+  clips: NewsClip[];
+  selectedDate: string | null; // YYYY-MM-DD
+  onSelectDate: (date: string | null) => void;
+  onRefreshEvents: (clipId: number) => Promise<void>;
+}
+
+// -------------------------------------------------------
+// 日付キー取得 (publishedAt 優先)
+// -------------------------------------------------------
+export function getClipDateKey(clip: NewsClip): string | null {
+  const dateStr = clip.publishedAt || clip.clippedAt;
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return null;
+  return toDateKey(date.getFullYear(), date.getMonth() + 1, date.getDate());
+}
+
+function toDateKey(y: number, m: number, d: number): string {
+  return `${y}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+}
+
+const WEEKDAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+
+export function NewsClipCalendar({
+  clips,
+  selectedDate,
+  onSelectDate,
+  onRefreshEvents,
+}: NewsClipCalendarProps) {
+  const [refreshingId, setRefreshingId] = useState<number | null>(null);
+
+  const initialDate = useMemo(() => {
+    const dates = clips
+      .map((c) => getClipDateKey(c))
+      .filter((d): d is string => d !== null)
+      .sort();
+    const latest = dates[dates.length - 1];
+    if (latest) {
+      const [y, m] = latest.split('-').map(Number);
+      return { year: y, month: m - 1 };
+    }
+    const now = new Date();
+    return { year: now.getFullYear(), month: now.getMonth() };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const [viewYear, setViewYear] = useState(initialDate.year);
+  const [viewMonth, setViewMonth] = useState(initialDate.month);
+
+  // クリップ公開日ごとの件数
+  const dateCounts = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const clip of clips) {
+      const d = getClipDateKey(clip);
+      if (d) map.set(d, (map.get(d) ?? 0) + 1);
+    }
+    return map;
+  }, [clips]);
+
+  // clip.events から日付ごとのイベントを集約
+  const eventsByDate = useMemo(() => {
+    const map = new Map<string, { label: string; clipId: number }[]>();
+    for (const clip of clips) {
+      for (const ev of clip.events) {
+        if (!map.has(ev.date)) map.set(ev.date, []);
+        map.get(ev.date)!.push({ label: ev.label, clipId: clip.id });
+      }
+    }
+    return map;
+  }, [clips]);
+
+  // events が空のクリップ（summary があるもの）は backfill 候補
+  const backfillCandidates = useMemo(
+    () => clips.filter((c) => c.events.length === 0 && !!c.summary),
+    [clips]
+  );
+
+  const prevMonth = () => {
+    if (viewMonth === 0) {
+      setViewMonth(11);
+      setViewYear((y) => y - 1);
+    } else setViewMonth((m) => m - 1);
+  };
+  const nextMonth = () => {
+    if (viewMonth === 11) {
+      setViewMonth(0);
+      setViewYear((y) => y + 1);
+    } else setViewMonth((m) => m + 1);
+  };
+
+  const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+  const today = new Date();
+  const todayKey = toDateKey(
+    today.getFullYear(),
+    today.getMonth() + 1,
+    today.getDate()
+  );
+  const monthPrefix = `${viewYear}-${String(viewMonth + 1).padStart(2, '0')}`;
+
+  const monthClipTotal = useMemo(
+    () =>
+      [...dateCounts.entries()]
+        .filter(([k]) => k.startsWith(monthPrefix))
+        .reduce((sum, [, c]) => sum + c, 0),
+    [dateCounts, monthPrefix]
+  );
+
+  const monthEventTotal = useMemo(
+    () =>
+      [...eventsByDate.entries()]
+        .filter(([k]) => k.startsWith(monthPrefix))
+        .reduce((sum, [, evs]) => sum + evs.length, 0),
+    [eventsByDate, monthPrefix]
+  );
+
+  const handleDayClick = (day: number) => {
+    const dateKey = toDateKey(viewYear, viewMonth + 1, day);
+    onSelectDate(selectedDate === dateKey ? null : dateKey);
+  };
+
+  const handleRefreshAll = async () => {
+    for (const clip of backfillCandidates) {
+      setRefreshingId(clip.id);
+      try {
+        await onRefreshEvents(clip.id);
+      } catch {
+        // エラーは個別にスキップ
+      }
+    }
+    setRefreshingId(null);
+  };
+
+  return (
+    <div className="flex flex-col select-none">
+      {/* 月ナビゲーション */}
+      <div className="flex items-center justify-between px-1 py-1.5 sticky top-0 bg-background z-10 border-b border-border/40">
+        <button
+          onClick={prevMonth}
+          className="p-1 rounded hover:bg-muted transition-colors"
+          aria-label="前月"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+        </button>
+        <div className="text-center">
+          <p className="text-xs font-semibold leading-none">
+            {viewYear}年{viewMonth + 1}月
+          </p>
+          <p className="text-[10px] text-muted-foreground mt-0.5">
+            {monthClipTotal > 0 && `記事${monthClipTotal}件`}
+            {monthClipTotal > 0 && monthEventTotal > 0 && ' / '}
+            {monthEventTotal > 0 && `予定${monthEventTotal}件`}
+          </p>
+        </div>
+        <button
+          onClick={nextMonth}
+          className="p-1 rounded hover:bg-muted transition-colors"
+          aria-label="翌月"
+        >
+          <ChevronRight className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {/* 日付リスト */}
+      <div className="flex flex-col py-0.5">
+        {Array.from({ length: daysInMonth }, (_, i) => i + 1).map((day) => {
+          const dateKey = toDateKey(viewYear, viewMonth + 1, day);
+          const count = dateCounts.get(dateKey) ?? 0;
+          const events = eventsByDate.get(dateKey) ?? [];
+          const hasClips = count > 0;
+          const hasAny = hasClips || events.length > 0;
+          const isSelected = selectedDate === dateKey;
+          const isToday = dateKey === todayKey;
+          const dayOfWeek = new Date(viewYear, viewMonth, day).getDay();
+
+          return (
+            <div key={day} className={cn(!hasAny && 'opacity-25')}>
+              {/* 日付行 */}
+              <button
+                onClick={() => hasClips && handleDayClick(day)}
+                disabled={!hasClips}
+                className={cn(
+                  'w-full flex items-center gap-1.5 px-2 py-1 rounded transition-colors text-xs',
+                  hasClips ? 'cursor-pointer hover:bg-muted' : 'cursor-default',
+                  isSelected &&
+                    'bg-primary text-primary-foreground hover:bg-primary/90'
+                )}
+              >
+                <span
+                  className={cn(
+                    'w-5 text-right font-mono leading-none shrink-0',
+                    isToday && !isSelected && 'font-bold'
+                  )}
+                >
+                  {day}
+                </span>
+                <span
+                  className={cn(
+                    'text-[10px] leading-none shrink-0',
+                    isSelected
+                      ? 'opacity-70'
+                      : dayOfWeek === 0
+                        ? 'text-red-500'
+                        : dayOfWeek === 6
+                          ? 'text-blue-500'
+                          : 'text-muted-foreground'
+                  )}
+                >
+                  {WEEKDAY_LABELS[dayOfWeek]}
+                </span>
+                {isToday && !isSelected && (
+                  <span className="text-[9px] text-primary leading-none">
+                    ●
+                  </span>
+                )}
+                {hasClips && (
+                  <span
+                    className={cn(
+                      'ml-auto text-[10px] leading-none px-1 py-0.5 rounded shrink-0',
+                      isSelected
+                        ? 'bg-primary-foreground/20 text-primary-foreground'
+                        : 'bg-primary/10 text-primary'
+                    )}
+                  >
+                    {count}
+                  </span>
+                )}
+              </button>
+
+              {/* AI 抽出イベントラベル */}
+              {events.map((ev, idx) => (
+                <div
+                  key={`${ev.clipId}-${idx}`}
+                  className="flex items-start gap-1 pl-8 pr-2 py-0.5"
+                  title={ev.label}
+                >
+                  <span className="mt-[3px] w-1.5 h-1.5 rounded-full bg-amber-500 shrink-0" />
+                  <span className="text-[10px] text-amber-600 dark:text-amber-400 leading-snug line-clamp-2">
+                    {ev.label}
+                  </span>
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* フィルター解除 */}
+      {selectedDate && (
+        <div className="px-2 py-1.5 border-t border-border/40 sticky bottom-0 bg-background">
+          <button
+            onClick={() => onSelectDate(null)}
+            className="text-[10px] text-muted-foreground hover:text-foreground underline transition-colors w-full text-center"
+          >
+            フィルター解除
+          </button>
+        </div>
+      )}
+
+      {/* backfill ボタン（events 未取得クリップがある場合のみ表示） */}
+      {backfillCandidates.length > 0 && (
+        <div className="px-2 py-2 border-t border-border/40">
+          <button
+            onClick={handleRefreshAll}
+            disabled={refreshingId !== null}
+            className="w-full flex items-center justify-center gap-1.5 text-[10px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+          >
+            <RefreshCw
+              className={cn('h-3 w-3', refreshingId !== null && 'animate-spin')}
+            />
+            {refreshingId !== null
+              ? 'イベント日付を取得中...'
+              : `イベント日付を取得 (${backfillCandidates.length}件)`}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/screens/news.tsx
+++ b/src/components/screens/news.tsx
@@ -1,5 +1,9 @@
 import { RefreshCw, Newspaper, Bookmark } from 'lucide-react';
 import { useState, useMemo, useRef } from 'react';
+import {
+  NewsClipCalendar,
+  getClipDateKey,
+} from '@/components/news/news-clip-calendar';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Button } from '@/components/ui/button';
 import { PageHeader } from '@/components/ui/page-header';
@@ -33,6 +37,7 @@ export function News() {
     clip,
     unclip,
     refresh: refreshClips,
+    refreshEvents,
   } = useNewsClips();
 
   const handleRefresh = () => {
@@ -162,7 +167,11 @@ export function News() {
           />
         )}
         {activeTab === 'clips' && (
-          <ClipsTab clips={filteredClips} onUnclip={unclip} />
+          <ClipsTab
+            clips={filteredClips}
+            onUnclip={unclip}
+            onRefreshEvents={refreshEvents}
+          />
         )}
       </div>
     </div>
@@ -328,6 +337,57 @@ function FeedTab({
 function ClipsTab({
   clips,
   onUnclip,
+  onRefreshEvents,
+}: {
+  clips: ReturnType<typeof useNewsClips>['clips'];
+  onUnclip: (id: number, url: string) => void;
+  onRefreshEvents: (clipId: number) => Promise<void>;
+}) {
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  const visibleClips = useMemo(
+    () =>
+      selectedDate === null
+        ? clips
+        : clips.filter((c) => getClipDateKey(c) === selectedDate),
+    [clips, selectedDate]
+  );
+
+  if (clips.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-48 text-muted-foreground">
+        <Bookmark className="h-10 w-10 mb-3 opacity-30" />
+        <p className="text-sm">クリップした記事がありません</p>
+        <p className="text-xs mt-1 opacity-70">
+          ニュース一覧のブックマークアイコンからクリップできます
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full gap-0">
+      {/* 左: クリップ一覧 (2/3) */}
+      <div className="flex-[2] min-w-0 h-full overflow-hidden">
+        <ClipsList clips={visibleClips} onUnclip={onUnclip} />
+      </div>
+
+      {/* 右: 月カレンダー (1/3) */}
+      <div className="flex-[1] min-w-0 h-full border-l border-border/50 px-2 py-1 overflow-y-auto">
+        <NewsClipCalendar
+          clips={clips}
+          selectedDate={selectedDate}
+          onSelectDate={setSelectedDate}
+          onRefreshEvents={onRefreshEvents}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ClipsList({
+  clips,
+  onUnclip,
 }: {
   clips: ReturnType<typeof useNewsClips>['clips'];
   onUnclip: (id: number, url: string) => void;
@@ -343,11 +403,8 @@ function ClipsTab({
   if (clips.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-48 text-muted-foreground">
-        <Bookmark className="h-10 w-10 mb-3 opacity-30" />
-        <p className="text-sm">クリップした記事がありません</p>
-        <p className="text-xs mt-1 opacity-70">
-          ニュース一覧のブックマークアイコンからクリップできます
-        </p>
+        <Bookmark className="h-8 w-8 mb-2 opacity-30" />
+        <p className="text-sm">この日の記事はありません</p>
       </div>
     );
   }

--- a/src/hooks/useNewsClips.ts
+++ b/src/hooks/useNewsClips.ts
@@ -7,6 +7,7 @@ import {
   getNewsClips,
   deleteNewsClip,
   getClippedUrls,
+  refreshClipEvents,
 } from '@/lib/news/clips';
 
 interface UseNewsClipsResult {
@@ -19,6 +20,7 @@ interface UseNewsClipsResult {
   clip: (item: NewsItem) => Promise<void>;
   unclip: (id: number, url: string) => Promise<void>;
   refresh: () => Promise<void>;
+  refreshEvents: (clipId: number) => Promise<void>;
 }
 
 export function useNewsClips(): UseNewsClipsResult {
@@ -93,5 +95,30 @@ export function useNewsClips(): UseNewsClipsResult {
     }
   }, []);
 
-  return { clips, clippedUrls, loading, clippingUrl, clip, unclip, refresh };
+  const refreshEvents = useCallback(async (clipId: number) => {
+    try {
+      const updated = await refreshClipEvents(clipId);
+      setClips((prev) => prev.map((c) => (c.id === clipId ? updated : c)));
+    } catch (e) {
+      const msg =
+        e instanceof Error
+          ? e.message
+          : typeof e === 'string'
+            ? e
+            : 'イベント取得に失敗しました';
+      toast.error(msg);
+      throw e;
+    }
+  }, []);
+
+  return {
+    clips,
+    clippedUrls,
+    loading,
+    clippingUrl,
+    clip,
+    unclip,
+    refresh,
+    refreshEvents,
+  };
 }

--- a/src/lib/news/clips.ts
+++ b/src/lib/news/clips.ts
@@ -1,5 +1,11 @@
 import { invoke } from '@tauri-apps/api/core';
 
+/** AI が抽出したイベント日付 */
+export interface ClipEvent {
+  date: string; // YYYY-MM-DD
+  label: string;
+}
+
 /** クリップ済み記事（フロントエンド用正規化型） */
 export interface NewsClip {
   id: number;
@@ -10,6 +16,7 @@ export interface NewsClip {
   summary?: string;
   tags: string[];
   clippedAt: string;
+  events: ClipEvent[];
 }
 
 /** Rust が返す snake_case の生型 */
@@ -22,6 +29,7 @@ interface RawNewsClip {
   summary?: string;
   tags: string[];
   clipped_at: string;
+  events: ClipEvent[];
 }
 
 function normalize(raw: RawNewsClip): NewsClip {
@@ -34,6 +42,7 @@ function normalize(raw: RawNewsClip): NewsClip {
     summary: raw.summary,
     tags: raw.tags,
     clippedAt: raw.clipped_at,
+    events: raw.events ?? [],
   };
 }
 
@@ -68,6 +77,12 @@ export async function getNewsClips(): Promise<NewsClip[]> {
 /** クリップを削除する */
 export async function deleteNewsClip(id: number): Promise<void> {
   await invoke('delete_news_clip', { id });
+}
+
+/** 既存クリップのイベント日付を AI で再抽出する */
+export async function refreshClipEvents(clipId: number): Promise<NewsClip> {
+  const raw = await invoke<RawNewsClip>('refresh_clip_events', { clipId });
+  return normalize(raw);
 }
 
 /** クリップ済み URL 一覧を取得する（ニュース一覧での既クリップ判定用） */


### PR DESCRIPTION
## Summary
- クリップタブを 2:1 レイアウトに変更（左: 記事一覧、右: 縦型月カレンダー）
- Gemini API を用いてクリップ記事の要約からイベント日付（発売日・予約開始日など）を自動抽出
- DB migration 004: `news_clips` テーブルに `events` 列（JSON）を追加
- 既存クリップ向け backfill ボタン（要約のみを使い API コール最小化）
- カレンダーで日付クリックによる記事フィルタリング機能

## Test plan
- [ ] 新規記事クリップ時に events が自動抽出されカレンダーに表示される
- [ ] backfill ボタンで既存クリップの events が取得できる
- [ ] カレンダーの日付クリックで左ペインの記事がフィルタリングされる
- [ ] 「フィルター解除」ボタンで全件表示に戻る
- [ ] events が空の場合でもカレンダーが正常表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)