### PR TITLE
fix: イベントティッカーのスクロール速度を件数によらず一定に・表示期間を1週間に制限

### DIFF
--- a/src/components/layout/event-ticker.tsx
+++ b/src/components/layout/event-ticker.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import { getNewsClips } from '@/lib/news/clips';
 import { cn } from '@/lib/utils';
 
@@ -21,17 +21,21 @@ function formatDate(dateStr: string): string {
   return `${year}/${month}/${day}`;
 }
 
+const TICKER_DAYS = 7;
+
 function collectUpcomingEvents(
   clips: Awaited<ReturnType<typeof getNewsClips>>
 ): TickerEvent[] {
   const todayStr = getTodayStr();
   const today = new Date(todayStr);
+  const limit = new Date(today);
+  limit.setDate(limit.getDate() + TICKER_DAYS);
 
   const events: TickerEvent[] = [];
   for (const clip of clips) {
     for (const ev of clip.events) {
       const evDate = new Date(ev.date);
-      if (evDate >= today) {
+      if (evDate >= today && evDate <= limit) {
         events.push({
           date: ev.date,
           label: ev.label,
@@ -46,6 +50,7 @@ function collectUpcomingEvents(
 }
 
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5分
+const PX_PER_SECOND = 80; // スクロール速度(px/秒)
 
 function TickerItem({ ev }: { ev: TickerEvent }) {
   return (
@@ -83,6 +88,8 @@ function TickerList({ events }: { events: TickerEvent[] }) {
 
 export function EventTicker() {
   const [events, setEvents] = useState<TickerEvent[]>([]);
+  const [duration, setDuration] = useState<number>(40);
+  const trackRef = useRef<HTMLDivElement>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
@@ -106,6 +113,15 @@ export function EventTicker() {
     };
   }, []);
 
+  // コンテンツ幅に応じてアニメーション時間を計算 (1周分 = 幅の半分)
+  useLayoutEffect(() => {
+    if (!trackRef.current) return;
+    const halfWidth = trackRef.current.scrollWidth / 2;
+    if (halfWidth > 0) {
+      setDuration(halfWidth / PX_PER_SECOND);
+    }
+  }, [events]);
+
   if (events.length === 0) return null;
 
   return (
@@ -119,7 +135,11 @@ export function EventTicker() {
       {/* スクロール領域 */}
       <div className="flex-1 overflow-hidden">
         {/* 2周分を並べてシームレスループ */}
-        <div className="ticker-track inline-flex items-center whitespace-nowrap">
+        <div
+          ref={trackRef}
+          className="ticker-track inline-flex items-center whitespace-nowrap"
+          style={{ animationDuration: `${duration}s` }}
+        >
           <TickerList events={events} />
           <TickerList events={events} />
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -102,7 +102,7 @@
 
 .ticker-track {
   display: inline-block;
-  animation: ticker-scroll 40s linear infinite;
+  animation: ticker-scroll 40s linear infinite; /* duration は JS で上書き */
 }
 
 .ticker-track:hover {


### PR DESCRIPTION
## Summary

- スクロール速度が件数によって変化していた問題を修正。`useLayoutEffect` でコンテンツ幅を計測し、`PX_PER_SECOND = 80px/秒` から `animationDuration` を動的に算出するよう変更
- 表示対象イベントを今日から **7日以内** に絞り込み（`TICKER_DAYS = 7`）

## Changes

- `src/components/layout/event-ticker.tsx`
  - `useLayoutEffect` でトラック幅を計測し `animationDuration` をスタイルで注入
  - `collectUpcomingEvents` に7日上限フィルタを追加
- `src/index.css`
  - CSS側の `40s` はフォールバックとして残しつつコメントで明示

## Reviewer Notes

- スクロール速度の定数 `PX_PER_SECOND` と表示期間の定数 `TICKER_DAYS` はファイル上部で調整可能
- イベントが0件の場合はティッカー自体が非表示になる既存挙動は変わらず

🤖 Generated with [Claude Code](https://claude.com/claude-code)