### PR TITLE
fix: Gemini モデルを gemini-2.5-flash-lite に更新

### DIFF
--- a/src-tauri/src/commands/news.rs
+++ b/src-tauri/src/commands/news.rs
@@ -566,7 +566,7 @@ async fn summarize_with_gemini(
         .map_err(|e| format!("HTTPクライアントの初期化に失敗: {e}"))?;
 
     let response = client
-        .post("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent")
+        .post("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent")
         .header("Content-Type", "application/json")
         .header("X-goog-api-key", api_key)
         .body(body)
@@ -652,7 +652,7 @@ async fn extract_events_with_gemini(
         .map_err(|e| format!("HTTPクライアントの初期化に失敗: {e}"))?;
 
     let response = client
-        .post("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-lite:generateContent")
+        .post("https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent")
         .header("Content-Type", "application/json")
         .header("X-goog-api-key", api_key)
         .body(body)

--- a/src-tauri/src/gemini/client.rs
+++ b/src-tauri/src/gemini/client.rs
@@ -225,12 +225,12 @@ impl GeminiClient {
         let http_client = Client::builder(TokioExecutor::new()).build(https);
 
         // セキュリティ: APIキーをログに出力しない
-        log::info!("GeminiClient created with model: gemini-2.0-flash-lite");
+        log::info!("GeminiClient created with model: gemini-2.5-flash-lite");
 
         Ok(Self {
             api_key,
             http_client,
-            model: "gemini-2.0-flash-lite".to_string(),
+            model: "gemini-2.5-flash-lite".to_string(),
         })
     }
 
@@ -604,7 +604,7 @@ mod tests {
                     .enable_http1()
                     .build(),
             ),
-            model: "gemini-2.0-flash-lite".to_string(),
+            model: "gemini-2.5-flash-lite".to_string(),
         };
 
         let prompt = client.build_prompt(&["KADOKAWA 1/7 レム".to_string()]);
@@ -627,7 +627,7 @@ mod tests {
                     .enable_http1()
                     .build(),
             ),
-            model: "gemini-2.0-flash-lite".to_string(),
+            model: "gemini-2.5-flash-lite".to_string(),
         };
 
         let prompt = client.build_prompt(&[
@@ -653,7 +653,7 @@ mod tests {
                     .enable_http1()
                     .build(),
             ),
-            model: "gemini-2.0-flash-lite".to_string(),
+            model: "gemini-2.5-flash-lite".to_string(),
         };
 
         let response_text = r#"[
@@ -693,7 +693,7 @@ mod tests {
                     .enable_http1()
                     .build(),
             ),
-            model: "gemini-2.0-flash-lite".to_string(),
+            model: "gemini-2.5-flash-lite".to_string(),
         };
 
         let invalid_json = "not valid json";
@@ -715,7 +715,7 @@ mod tests {
                     .enable_http1()
                     .build(),
             ),
-            model: "gemini-2.0-flash-lite".to_string(),
+            model: "gemini-2.5-flash-lite".to_string(),
         };
 
         // 配列形式だが要素がParsedProductの型と合わない

--- a/src-tauri/src/gemini/ocr.rs
+++ b/src-tauri/src/gemini/ocr.rs
@@ -12,7 +12,7 @@ use hyper_util::client::legacy::Client;
 use hyper_util::rt::TokioExecutor;
 use std::time::Duration;
 
-const OCR_MODEL: &str = "gemini-2.0-flash-lite";
+const OCR_MODEL: &str = "gemini-2.5-flash-lite";
 const OCR_TIMEOUT_SECS: u64 = 30;
 
 /// 画像バイト列（PNG）をGemini Vision APIでOCR処理し、テキストを返す


### PR DESCRIPTION
## Summary

- `gemini-2.0-flash-lite` が廃止されて 404 エラーが発生していた
- 後継モデルの `gemini-2.5-flash-lite` に全箇所を置き換え（`client.rs`, `ocr.rs`, `news.rs`）

## Test plan

- [ ] アプリを起動して Gemini API エラーが出なくなることを確認
- [ ] 商品名パース機能が正常動作することを確認
- [ ] ニュース要約・イベント抽出機能が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)